### PR TITLE
Implement collapsible day groups

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -994,7 +994,7 @@ export default function App() {
             {collapsedDays.has(day) && !isExportingPdf ? (
               <div onClick={() => toggleDay(day)} style={styles.dayCover(dark)}>{day}</div>
             ) : (
-              <>
+              <React.Fragment>
                 <div onClick={() => toggleDay(day)} style={styles.groupHeader}>{day}</div>
                 {grouped[day].map(({ entry, idx }) => {
               const isSymptomOnlyEntry = !entry.food && (entry.symptoms || []).length > 0;
@@ -1173,8 +1173,9 @@ export default function App() {
                   )}
                 </div>
               );
-              })
-              </>
+              })}
+              </React.Fragment>
+            )}
           </div>
         ))}
       </div>

--- a/src/App.js
+++ b/src/App.js
@@ -1173,7 +1173,7 @@ export default function App() {
                   )}
                 </div>
               );
-            })}
+              })
               </>
           </div>
         ))}


### PR DESCRIPTION
## Summary
- add a style for collapsed day covers
- compute today's date and track collapsed days
- auto-collapse past days and allow toggling days open or closed
- show collapsed cover when not exporting PDF

## Testing
- `npm test --silent` *(fails: react-scripts not found)*
- `npm run build --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843dad00f688332b7d86c4548ca7cdf