### PR TITLE
Adjust PDF background color

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -685,6 +685,7 @@ export default function App() {
         windowWidth: el.scrollWidth,
         windowHeight: el.scrollHeight,
         useCORS: true,
+        backgroundColor: '#e0e0e0', // medium light grey background for PDF
       });
       const imgData = canvas.toDataURL("image/png");
       const pdf = new jsPDF({ unit: "px", format: [canvas.width, canvas.height] });


### PR DESCRIPTION
## Summary
- export PDF with grey background instead of white

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6844275a7a088332aed2435840d63264