### PR TITLE
Add hexagon mesh background for PDF export

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -660,6 +660,7 @@ export default function App() {
 
     const imgStackItemOriginalStyles = [];
     const individualImageOriginalStyles = [];
+    let prevClassName = '';
 
     try {
       const imgStackContainers = Array.from(el.querySelectorAll(".img-stack-container"));
@@ -680,13 +681,20 @@ export default function App() {
         img.style.objectFit = "contain";
       });
 
+      // Temporäres hexagonales Hintergrundmuster für den PDF-Export setzen
+      prevClassName = el.className;
+      el.classList.add('pdf-hex-bg');
+
       const canvas = await html2canvas(el, {
         scale: 2,
         windowWidth: el.scrollWidth,
         windowHeight: el.scrollHeight,
         useCORS: true,
-        backgroundColor: '#e0e0e0', // medium light grey background for PDF
+        backgroundColor: null,
       });
+
+      // Ursprüngliche Klassen wiederherstellen
+      el.className = prevClassName;
       const imgData = canvas.toDataURL("image/png");
       const pdf = new jsPDF({ unit: "px", format: [canvas.width, canvas.height] });
       pdf.addImage(imgData, "PNG", 0, 0, canvas.width, canvas.height);
@@ -706,6 +714,7 @@ export default function App() {
         orig.el.style.height = orig.height;
         orig.el.style.objectFit = orig.objectFit;
       });
+      if (prevClassName) el.className = prevClassName;
       setIsExportingPdf(false);
     }
   };

--- a/src/index.css
+++ b/src/index.css
@@ -28,3 +28,16 @@ code {
   opacity: 0;
   transition: opacity 0.3s ease;
 }
+
+.pdf-hex-bg {
+  background-color: #777;
+  background-image:
+    linear-gradient(30deg, #888 12%, transparent 12.5%, transparent 87%, #888 87.5%, #888),
+    linear-gradient(150deg, #888 12%, transparent 12.5%, transparent 87%, #888 87.5%, #888),
+    linear-gradient(30deg, #666 12%, transparent 12.5%, transparent 87%, #666 87.5%, #666),
+    linear-gradient(150deg, #666 12%, transparent 12.5%, transparent 87%, #666 87.5%, #666),
+    linear-gradient(60deg, #555 25%, transparent 25.5%, transparent 75%, #555 75%, #555),
+    linear-gradient(60deg, #555 25%, transparent 25.5%, transparent 75%, #555 75%, #555);
+  background-size: 40px 69.28px;
+  background-position: 0 0, 0 0, 20px 34.64px, 20px 34.64px, 10px 17.32px, 10px 17.32px;
+}


### PR DESCRIPTION
## Summary
- add hexagon pattern style for PDF background
- apply hexagon background to fd-table during PDF export

## Testing
- `npm install`
- `CI=true npm test -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68442b2665e88332b29e1ba8cbd5aed6