### PR TITLE
Update pin layout and pencil orientation

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -146,7 +146,7 @@ const styles = {
   }),
   rotatedIcon: {
     display: 'inline-block',
-    transform: 'rotate(270deg)', // Winkel wie vom User zuletzt bereitgestellt
+    transform: 'rotate(90deg)', // Zurück zur vorherigen Ausrichtung
   },
   actionMenu: (dark) => ({
     position: 'absolute',
@@ -226,11 +226,11 @@ const styles = {
   },
   pin: (selected) => ({
     position: 'absolute',
-    top: '50%',
-    left: '50%',
+    top: '2px',
+    left: '2px',
     width: '16px',
     height: '16px',
-    transform: 'translate(-50%, -50%) rotate(270deg)',
+    transform: 'rotate(270deg)',
     cursor: 'pointer',
     pointerEvents: 'auto',
     zIndex: 5,
@@ -698,8 +698,8 @@ export default function App() {
             const eRect = endEl.getBoundingClientRect();
             conns.push({
               id,
-              top: sRect.top - cRect.top + sRect.height / 2,
-              bottom: eRect.top - cRect.top + eRect.height / 2,
+              top: sRect.top - cRect.top,
+              bottom: eRect.top - cRect.top,
             });
           }
         }


### PR DESCRIPTION
## Summary
- align pin icon to entry's top left corner
- start connection brackets at top left
- revert pencil edit icon orientation

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68446877cd3483328f67d904d5f8e3c5