### PR TITLE
Adjust PDF export styling

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -642,18 +642,19 @@ export default function App() {
       {/* Eintragsliste */}
       <div id="fd-table" style={{position:'relative'}}>
         {connections.map(c => {
-          const offset = -c.lane * 5;
+          const startX = isExportingPdf ? 20 : 10;
+          const offset = isExportingPdf ? startX - 10 - c.lane * 5 : -c.lane * 5;
           const height = c.bottom - c.top;
-          let d = `M10 0 H${offset} V${height} H10`;
+          let d = `M${startX} 0 H${offset} V${height} H${startX}`;
           c.cross.forEach(y => {
-            d += ` M10 ${y} H${offset}`;
+            d += ` M${startX} ${y} H${offset}`;
           });
           return (
             <svg
               key={c.id}
               className="connection-line"
               onClick={(e) => { e.stopPropagation(); handleConnectionClick(c.id); }}
-              style={{...styles.connectionSvg, top: c.top, height}}
+              style={{...styles.connectionSvg(isExportingPdf), top: c.top, height}}
             >
               <path
                 d={d}

--- a/src/App.js
+++ b/src/App.js
@@ -673,7 +673,7 @@ export default function App() {
                 <div style={{display:'flex',alignItems:'center',justifyContent:'center',gap:8}}>
                   <button
                     onClick={e => { e.stopPropagation(); toggleDay(day); }}
-                    style={styles.collapseButton(dark)}
+                    style={styles.collapseButton(dark, isExportingPdf)}
                     aria-label="Expand day"
                   >
                     ▶
@@ -686,7 +686,7 @@ export default function App() {
                 <div onClick={() => toggleDay(day)} style={styles.groupHeader(isExportingPdf)}>
                   <button
                     onClick={e => { e.stopPropagation(); toggleDay(day); }}
-                    style={styles.collapseButton(dark)}
+                    style={styles.collapseButton(dark, isExportingPdf)}
                     aria-label="Collapse day"
                   >
                     ▼

--- a/src/index.css
+++ b/src/index.css
@@ -31,5 +31,5 @@ code {
 
 .pdf-hex-bg {
   /* Simplified background for PDF export */
-  background-color: #bdbdbd;
+  background-color: #4c4c4c;
 }

--- a/src/index.css
+++ b/src/index.css
@@ -31,5 +31,5 @@ code {
 
 .pdf-hex-bg {
   /* Simplified background for PDF export */
-  background-color: #4c4c4c;
+  background-color: #262626;
 }

--- a/src/styles.js
+++ b/src/styles.js
@@ -96,7 +96,8 @@ const styles = {
     color: isPdf ? '#333' : undefined,
     display: 'flex',
     alignItems: 'center',
-    gap: '8px'
+    gap: '8px',
+    marginLeft: 5
   }),
   dayCover: (dark) => ({
     fontSize: 18,
@@ -148,6 +149,7 @@ const styles = {
       : (dark ? '1px solid rgba(255, 255, 255, 0.15)' : '1px solid rgba(0, 0, 0, 0.1)'),
     borderRadius: 6,
     padding: '4px 6px',
+    marginLeft: 5,
     cursor: 'pointer',
     fontSize: 14,
     lineHeight: 1,
@@ -231,14 +233,14 @@ const styles = {
     justifyContent: 'center',
     fontSize: '14px',
   }),
-  connectionSvg: {
+  connectionSvg: (isPdf = false) => ({
     position: 'absolute',
-    left: '0px',
-    width: '20px',
+    left: isPdf ? '-10px' : '0px',
+    width: isPdf ? '30px' : '20px',
     pointerEvents: 'auto',
     overflow: 'visible',
     cursor: 'pointer',
-  },
+  }),
 };
 
 export default styles;

--- a/src/styles.js
+++ b/src/styles.js
@@ -141,15 +141,17 @@ const styles = {
     alignItems: 'center',
     justifyContent: 'center',
   }),
-  collapseButton: (dark) => ({
+  collapseButton: (dark, isPdf = false) => ({
     background: dark ? 'rgba(255, 255, 255, 0.08)' : 'rgba(0, 0, 0, 0.04)',
-    border: dark ? '1px solid rgba(255, 255, 255, 0.15)' : '1px solid rgba(0, 0, 0, 0.1)',
+    border: isPdf
+      ? '1px solid #333'
+      : (dark ? '1px solid rgba(255, 255, 255, 0.15)' : '1px solid rgba(0, 0, 0, 0.1)'),
     borderRadius: 6,
     padding: '4px 6px',
     cursor: 'pointer',
     fontSize: 14,
     lineHeight: 1,
-    color: dark ? '#f0f0f8' : '#333',
+    color: isPdf ? '#333' : (dark ? '#f0f0f8' : '#333'),
     display: 'flex',
     alignItems: 'center',
     justifyContent: 'center',

--- a/src/utils/pdf.js
+++ b/src/utils/pdf.js
@@ -40,7 +40,7 @@ export async function exportTableToPdf(el) {
 
     el.className = prevClassName;
     const imgData = canvas.toDataURL('image/png');
-    const margin = 10;
+    const margin = 20;
     const pdfWidth = canvas.width - margin;
     const pdfHeight = canvas.height - margin;
     const pdf = new jsPDF({ unit: 'px', format: [pdfWidth, pdfHeight] });

--- a/src/utils/pdf.js
+++ b/src/utils/pdf.js
@@ -40,8 +40,11 @@ export async function exportTableToPdf(el) {
 
     el.className = prevClassName;
     const imgData = canvas.toDataURL('image/png');
-    const pdf = new jsPDF({ unit: 'px', format: [canvas.width, canvas.height] });
-    pdf.addImage(imgData, 'PNG', 0, 0, canvas.width, canvas.height);
+    const margin = 10;
+    const pdfWidth = canvas.width - margin;
+    const pdfHeight = canvas.height - margin;
+    const pdf = new jsPDF({ unit: 'px', format: [pdfWidth, pdfHeight] });
+    pdf.addImage(imgData, 'PNG', 0, 0, pdfWidth, pdfHeight);
     pdf.save('FoodDiary.pdf');
     return true;
   } catch (error) {


### PR DESCRIPTION
## Summary
- darken PDF background
- shrink PDF export by 10px to capture links
- ensure collapse arrows are dark in PDF export

## Testing
- `npm install`
- `CI=true npm test -- --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_684567f1d82c8332acaa36f398dd3b95