### PR TITLE
Improve PDF export visibility

### DIFF
--- a/src/utils/pdf.js
+++ b/src/utils/pdf.js
@@ -30,6 +30,9 @@ export async function exportTableToPdf(el) {
     prevClassName = el.className;
     el.classList.add('pdf-hex-bg');
 
+    const originalPaddingLeft = el.style.paddingLeft;
+    el.style.paddingLeft = '30px';
+
     const canvas = await html2canvas(el, {
       scale: 2,
       windowWidth: el.scrollWidth,
@@ -38,10 +41,13 @@ export async function exportTableToPdf(el) {
       backgroundColor: null,
     });
 
+    el.style.paddingLeft = originalPaddingLeft;
+
     el.className = prevClassName;
+    const zoomFactor = 0.75;
     const imgData = canvas.toDataURL('image/png');
-    const pdf = new jsPDF({ unit: 'px', format: [canvas.width, canvas.height] });
-    pdf.addImage(imgData, 'PNG', 0, 0, canvas.width, canvas.height);
+    const pdf = new jsPDF({ unit: 'px', format: [canvas.width * zoomFactor, canvas.height * zoomFactor] });
+    pdf.addImage(imgData, 'PNG', 0, 0, canvas.width * zoomFactor, canvas.height * zoomFactor);
     pdf.save('FoodDiary.pdf');
     return true;
   } catch (error) {


### PR DESCRIPTION
## Summary
- adjust padding to capture connection lines in exports
- scale down generated PDF image to fit more lines

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68456f934a2083328b3259f16d4e8ae9