### PR TITLE
Add new Supplemente tag color

### DIFF
--- a/src/components/EntryCard.js
+++ b/src/components/EntryCard.js
@@ -364,7 +364,7 @@ export default function EntryCard({
                 style={styles.colorPickerPopup(dark)}
                 onClick={e => e.stopPropagation()}
               >
-                {[TAG_COLORS.GREEN, TAG_COLORS.RED, TAG_COLORS.YELLOW, TAG_COLORS.BROWN].map(colorValue => (
+                {[TAG_COLORS.GREEN, TAG_COLORS.RED, TAG_COLORS.YELLOW, TAG_COLORS.BROWN, TAG_COLORS.BLUE].map(colorValue => (
                   <div
                     key={colorValue}
                     style={styles.colorPickerItem(colorValue, currentTagColor === colorValue, dark)}

--- a/src/constants.js
+++ b/src/constants.js
@@ -18,12 +18,14 @@ const TAG_COLORS = {
   RED: 'red',
   YELLOW: 'yellow',
   BROWN: '#c19a6b', // light brown for bowel movement
+  BLUE: '#90caf9',  // light blue for supplements
 };
 const TAG_COLOR_NAMES = {
   [TAG_COLORS.GREEN]: "Standard",
   [TAG_COLORS.RED]: "Symptome",
   [TAG_COLORS.YELLOW]: "Vorgeschichte",
   [TAG_COLORS.BROWN]: "Stuhlgang",
+  [TAG_COLORS.BLUE]: "Supplemente",
 };
 
 export { SYMPTOM_CHOICES, TIME_CHOICES, TAG_COLORS, TAG_COLOR_NAMES };

--- a/src/constants.js
+++ b/src/constants.js
@@ -18,7 +18,7 @@ const TAG_COLORS = {
   RED: 'red',
   YELLOW: 'yellow',
   BROWN: '#c19a6b', // light brown for bowel movement
-  BLUE: '#90caf9',  // light blue for supplements
+  BLUE: '#64b5f6',  // light blue for supplements
 };
 const TAG_COLOR_NAMES = {
   [TAG_COLORS.GREEN]: "Standard",


### PR DESCRIPTION
## Summary
- add light blue color constant
- support Supplemente in color picker

## Testing
- `npm install`
- `CI=true npm test --silent` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_684598183910833289424b95ca53787d