### PR TITLE
Improve PDF export and add print support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@testing-library/react": "^16.3.0",
         "@testing-library/user-event": "^13.5.0",
         "html2canvas": "^1.4.1",
+        "html2pdf.js": "^0.10.3",
         "jspdf": "^3.0.1",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
@@ -7178,6 +7179,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/es6-promise": {
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
+      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
+      "license": "MIT"
+    },
     "node_modules/escalade": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
@@ -9083,6 +9090,17 @@
       },
       "engines": {
         "node": ">=8.0.0"
+      }
+    },
+    "node_modules/html2pdf.js": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/html2pdf.js/-/html2pdf.js-0.10.3.tgz",
+      "integrity": "sha512-RcB1sh8rs5NT3jgbN5zvvTmkmZrsUrxpZ/RI8TMbvuReNZAdJZG5TMfA2TBP6ZXxpXlWf9NB/ciLXVb6W2LbRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es6-promise": "^4.2.5",
+        "html2canvas": "^1.0.0",
+        "jspdf": "^3.0.0"
       }
     },
     "node_modules/htmlparser2": {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^13.5.0",
     "html2canvas": "^1.4.1",
+    "html2pdf.js": "^0.10.3",
     "jspdf": "^3.0.1",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",

--- a/src/App.js
+++ b/src/App.js
@@ -8,6 +8,7 @@ import styles from "./styles";
 import { SYMPTOM_CHOICES, TIME_CHOICES, TAG_COLORS, TAG_COLOR_NAMES } from "./constants";
 import { resizeToJpeg, now, vibrate, getTodayDateString, parseDateString, toDateTimePickerFormat, fromDateTimePickerFormat, sortSymptomsByTime } from "./utils";
 import PdfButton from "./components/PdfButton";
+import PrintButton from "./components/PrintButton";
 import InsightsButton from "./components/InsightsButton";
 import BackButton from "./components/BackButton";
 import CameraButton from "./components/CameraButton";
@@ -243,6 +244,10 @@ export default function App() {
     if (ok) addToast("PDF erfolgreich exportiert!");
     else addToast("Fehler beim PDF-Export.");
     setIsExportingPdf(false);
+  };
+
+  const handlePrint = () => {
+    window.print();
   };
 
   const handleNewFile = async e => {
@@ -591,7 +596,12 @@ export default function App() {
     return (
       <div ref={containerRef} style={styles.container(isMobile)} onMouseDownCapture={handleRootMouseDown} onClick={handleContainerClick}>
         {toasts.map(t => <div key={t.id} className="toast-fade" style={styles.toast}>{t.msg}</div>)}
-        <div style={styles.topBar}><BackButton onClick={() => setView("diary")} /></div>
+        <div style={styles.topBar} className="top-bar">
+          <BackButton onClick={() => setView("diary")} />{" "}
+          <div>
+            <PrintButton onClick={handlePrint} />
+          </div>
+        </div>
         <Insights entries={entries} />
       </div>
     );
@@ -600,12 +610,13 @@ export default function App() {
   return (
     <div ref={containerRef} style={styles.container(isMobile)} onMouseDownCapture={handleRootMouseDown} onClick={handleContainerClick}>
       {toasts.map(t => <div key={t.id} className="toast-fade" style={styles.toast}>{t.msg}</div>)}
-      <div style={styles.topBar}>
+      <div style={styles.topBar} className="top-bar">
         <button onClick={() => setDark(d => !d)} style={{ ...styles.buttonSecondary("transparent"), fontSize: 24, color: dark ? '#f0f0f8' : '#111' }} title="Theme wechseln">
           {dark ? "🌙" : "☀️"}
         </button>
         <div>
           <PdfButton onClick={handleExportPDF} />{" "}
+          <PrintButton onClick={handlePrint} />{" "}
           <InsightsButton onClick={() => setView("insights")} />
         </div>
       </div>

--- a/src/components/NewEntryForm.js
+++ b/src/components/NewEntryForm.js
@@ -27,7 +27,7 @@ export default function NewEntryForm({
   styles
 }) {
   return (
-    <div style={{ marginBottom: 24 }}>
+    <div className="new-entry-form" style={{ marginBottom: 24 }}>
       <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 8 }}>
         <input
           placeholder="Eintrag..."

--- a/src/components/PrintButton.js
+++ b/src/components/PrintButton.js
@@ -1,0 +1,8 @@
+import React from "react";
+import styles from "../styles";
+
+const PrintButton = ({ onClick }) => (
+  <button onClick={onClick} className="haptic" title="Print" style={styles.buttonSecondary("#5e35b1")}>Print</button>
+);
+
+export default PrintButton;

--- a/src/index.css
+++ b/src/index.css
@@ -33,3 +33,18 @@ code {
   /* Simplified background for PDF export */
   background-color: #bdbdbd;
 }
+
+@media print {
+  body {
+    -webkit-print-color-adjust: exact;
+  }
+  .top-bar,
+  .toast-fade,
+  .new-entry-form,
+  button {
+    display: none !important;
+  }
+  #fd-table {
+    page-break-inside: avoid;
+  }
+}

--- a/src/utils/pdf.js
+++ b/src/utils/pdf.js
@@ -1,5 +1,4 @@
-import jsPDF from 'jspdf';
-import html2canvas from 'html2canvas';
+import html2pdf from 'html2pdf.js';
 
 export async function exportTableToPdf(el) {
   if (!el) return;
@@ -30,19 +29,13 @@ export async function exportTableToPdf(el) {
     prevClassName = el.className;
     el.classList.add('pdf-hex-bg');
 
-    const canvas = await html2canvas(el, {
-      scale: 2,
-      windowWidth: el.scrollWidth,
-      windowHeight: el.scrollHeight,
-      useCORS: true,
-      backgroundColor: null,
-    });
-
+    await html2pdf().from(el).set({
+      margin: 10,
+      filename: 'FoodDiary.pdf',
+      html2canvas: { scale: 2, useCORS: true, backgroundColor: null },
+      jsPDF: { unit: 'pt', format: 'a4', orientation: 'portrait' }
+    }).save();
     el.className = prevClassName;
-    const imgData = canvas.toDataURL('image/png');
-    const pdf = new jsPDF({ unit: 'px', format: [canvas.width, canvas.height] });
-    pdf.addImage(imgData, 'PNG', 0, 0, canvas.width, canvas.height);
-    pdf.save('FoodDiary.pdf');
     return true;
   } catch (error) {
     console.error('Fehler beim Erstellen des PDFs:', error);


### PR DESCRIPTION
## Summary
- add html2pdf.js dependency
- rewrite `exportTableToPdf` using html2pdf.js
- add print option and `PrintButton`
- hide UI during print with new styles
- mark new entry form for print CSS

## Testing
- `CI=true npm test --silent -- --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_68459de665d88332b8de6cffc24dd521