### PR TITLE
Improve printing and PDF export

### DIFF
--- a/src/hooks/useConnections.js
+++ b/src/hooks/useConnections.js
@@ -1,6 +1,6 @@
 import { useLayoutEffect, useState } from 'react';
 
-export default function useConnections(entries, searchTerm, displayCount, collapsedDays, entryRefs) {
+export default function useConnections(entries, searchTerm, displayCount, collapsedDays, entryRefs, extraFlag) {
   const [connections, setConnections] = useState([]);
 
   useLayoutEffect(() => {
@@ -67,7 +67,7 @@ export default function useConnections(entries, searchTerm, displayCount, collap
       window.removeEventListener('scroll', updateConnections);
       window.removeEventListener('resize', updateConnections);
     };
-  }, [entries, searchTerm, displayCount, collapsedDays]);
+  }, [entries, searchTerm, displayCount, collapsedDays, extraFlag]);
 
   return connections;
 }

--- a/src/index.css
+++ b/src/index.css
@@ -29,10 +29,6 @@ code {
   transition: opacity 0.3s ease;
 }
 
-.pdf-hex-bg {
-  /* Simplified background for PDF export */
-  background-color: #bdbdbd;
-}
 
 @media print {
   body {

--- a/src/utils/pdf.js
+++ b/src/utils/pdf.js
@@ -5,7 +5,7 @@ export async function exportTableToPdf(el) {
 
   const imgStackItemOriginalStyles = [];
   const individualImageOriginalStyles = [];
-  let prevClassName = '';
+  let prevBackground = '';
 
   try {
     const imgStackContainers = Array.from(el.querySelectorAll('.img-stack-container'));
@@ -26,16 +26,17 @@ export async function exportTableToPdf(el) {
       img.style.objectFit = 'contain';
     });
 
-    prevClassName = el.className;
-    el.classList.add('pdf-hex-bg');
+    prevBackground = el.style.backgroundColor;
+    const bodyBg = getComputedStyle(document.body).backgroundColor;
+    el.style.backgroundColor = bodyBg;
 
     await html2pdf().from(el).set({
       margin: 10,
       filename: 'FoodDiary.pdf',
-      html2canvas: { scale: 2, useCORS: true, backgroundColor: null },
+      html2canvas: { scale: 2, useCORS: true, backgroundColor: bodyBg },
       jsPDF: { unit: 'pt', format: 'a4', orientation: 'portrait' }
     }).save();
-    el.className = prevClassName;
+    el.style.backgroundColor = prevBackground;
     return true;
   } catch (error) {
     console.error('Fehler beim Erstellen des PDFs:', error);
@@ -50,6 +51,6 @@ export async function exportTableToPdf(el) {
       orig.el.style.height = orig.height;
       orig.el.style.objectFit = orig.objectFit;
     });
-    if (prevClassName) el.className = prevClassName;
+    if (prevBackground) el.style.backgroundColor = prevBackground;
   }
 }


### PR DESCRIPTION
## Summary
- render all entries when printing
- treat printing like PDF export for editing and collapsed days
- recalc entry connections when exporting or printing
- match PDF colors with app styles

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845a568fae483328041b87ba3cb29d8