### PR TITLE
Include notes in print

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -717,6 +717,7 @@ export default function App() {
             dark={dark}
             isMobile={isMobile}
             isExportingPdf={isExportingPdf || isPrinting}
+            isPrinting={isPrinting}
             editingIdx={editingIdx}
             editForm={editForm}
             setEditForm={setEditForm}

--- a/src/components/EntryCard.js
+++ b/src/components/EntryCard.js
@@ -7,6 +7,7 @@ export default function EntryCard({
   dark,
   isMobile,
   isExportingPdf,
+  isPrinting,
   editingIdx,
   editForm,
   setEditForm,
@@ -317,7 +318,7 @@ export default function EntryCard({
               </button>
             </div>
           )}
-          {entry.comment && noteOpenIdx !== idx && !isExportingPdf && (
+          {entry.comment && noteOpenIdx !== idx && (!isExportingPdf || isPrinting) && (
             <div
               id={`displayed-note-text-${idx}`}
               onClick={e => {

--- a/src/index.css
+++ b/src/index.css
@@ -43,4 +43,8 @@ code {
   #fd-table {
     page-break-inside: avoid;
   }
+  [id^="entry-card-"] {
+    break-inside: avoid;
+    page-break-inside: avoid;
+  }
 }

--- a/src/styles.js
+++ b/src/styles.js
@@ -88,6 +88,8 @@ const styles = {
       ? (dark ? "#3c3c46" : "#f0f0f5")
       : (dark ? "#2a2a32" : "#fff"),
     boxShadow: "0 1px 4px #0002",
+    pageBreakInside: 'avoid',
+    breakInside: 'avoid'
   }),
   groupHeader: (isPdf) => ({
     fontSize: 18,


### PR DESCRIPTION
## Summary
- show note text during printing
- avoid page breaks within entry cards

## Testing
- `npm install`
- `CI=true npm test -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_6845b11fc5208332bf77c07f80ebc092