### PR TITLE
Add quick menu and favorites

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -90,8 +90,12 @@ export default function App() {
   });
   const [favoriteSymptoms, setFavoriteSymptoms] = useState(() => {
     try {
-      return JSON.parse(localStorage.getItem('fd-fav-symptoms') || '[]');
-    } catch { return []; }
+      const stored = JSON.parse(localStorage.getItem('fd-fav-symptoms'));
+      if (stored && Array.isArray(stored) && stored.length > 0) return stored;
+      return SYMPTOM_CHOICES.slice();
+    } catch {
+      return SYMPTOM_CHOICES.slice();
+    }
   });
   const [showFoodQuick, setShowFoodQuick] = useState(false);
   const [showSymptomQuick, setShowSymptomQuick] = useState(false);
@@ -692,7 +696,6 @@ export default function App() {
         dark={dark}
         isMobile={isMobile}
         handleFocus={handleFocus}
-        SYMPTOM_CHOICES={SYMPTOM_CHOICES}
         TIME_CHOICES={TIME_CHOICES}
         sortSymptomsByTime={sortSymptomsByTime}
         SymTag={SymTag}

--- a/src/App.js
+++ b/src/App.js
@@ -99,6 +99,7 @@ export default function App() {
   });
   const [showFoodQuick, setShowFoodQuick] = useState(false);
   const [showSymptomQuick, setShowSymptomQuick] = useState(false);
+  const [showEditFoodQuick, setShowEditFoodQuick] = useState(false);
   const [showEditSymptomQuick, setShowEditSymptomQuick] = useState(false);
 
   // keep ref in sync so event handlers see latest state immediately
@@ -199,6 +200,10 @@ export default function App() {
         const area = document.getElementById('symptom-input-container');
         if (area && !area.contains(e.target)) setShowSymptomQuick(false);
       }
+      if (showEditFoodQuick) {
+        const area = document.getElementById('edit-food-input-container');
+        if (area && !area.contains(e.target)) setShowEditFoodQuick(false);
+      }
       if (showEditSymptomQuick) {
         const area = document.getElementById('edit-symptom-input-container');
         if (area && !area.contains(e.target)) setShowEditSymptomQuick(false);
@@ -206,7 +211,7 @@ export default function App() {
     };
     document.addEventListener('mousedown', handleQuickClose);
     return () => document.removeEventListener('mousedown', handleQuickClose);
-  }, [showFoodQuick, showSymptomQuick, showEditSymptomQuick]);
+  }, [showFoodQuick, showSymptomQuick, showEditFoodQuick, showEditSymptomQuick]);
 
   const knownDaysRef = useRef(new Set());
 
@@ -409,11 +414,13 @@ export default function App() {
     });
     setColorPickerOpenForIdx(null);
     setNoteOpenIdx(null);
+    setShowEditFoodQuick(false);
     setShowEditSymptomQuick(false);
   };
   const cancelEdit = () => {
     setEditingIdx(null);
     setEditForm(null);
+    setShowEditFoodQuick(false);
     setShowEditSymptomQuick(false);
   };
 
@@ -860,6 +867,8 @@ export default function App() {
             SymTag={SymTag}
             styles={styles}
             QuickMenu={QuickMenu}
+            showEditFoodQuick={showEditFoodQuick}
+            setShowEditFoodQuick={setShowEditFoodQuick}
             showEditSymptomQuick={showEditSymptomQuick}
             setShowEditSymptomQuick={setShowEditSymptomQuick}
                   />

--- a/src/App.js
+++ b/src/App.js
@@ -17,6 +17,7 @@ import SymTag from "./components/SymTag";
 import Insights from "./components/Insights";
 import NewEntryForm from "./components/NewEntryForm";
 import EntryCard from "./components/EntryCard";
+import QuickMenu from "./components/QuickMenu";
 
 // spacing and sizing for collapsed day indicators
 const DAY_MARK_SPACING = 25;
@@ -82,6 +83,18 @@ export default function App() {
   const linkingInfoRef = useRef(null);
   const containerRef = useRef(null);
   const entryRefs = useRef([]);
+  const [favoriteFoods, setFavoriteFoods] = useState(() => {
+    try {
+      return JSON.parse(localStorage.getItem('fd-fav-foods') || '[]');
+    } catch { return []; }
+  });
+  const [favoriteSymptoms, setFavoriteSymptoms] = useState(() => {
+    try {
+      return JSON.parse(localStorage.getItem('fd-fav-symptoms') || '[]');
+    } catch { return []; }
+  });
+  const [showFoodQuick, setShowFoodQuick] = useState(false);
+  const [showSymptomQuick, setShowSymptomQuick] = useState(false);
 
   // keep ref in sync so event handlers see latest state immediately
   useEffect(() => {
@@ -128,6 +141,14 @@ export default function App() {
   useEffect(() => {
     localStorage.setItem("fd-form-new", JSON.stringify(newForm));
   }, [newForm]);
+
+  useEffect(() => {
+    localStorage.setItem('fd-fav-foods', JSON.stringify(favoriteFoods));
+  }, [favoriteFoods]);
+
+  useEffect(() => {
+    localStorage.setItem('fd-fav-symptoms', JSON.stringify(favoriteSymptoms));
+  }, [favoriteSymptoms]);
 
   useEffect(() => {
     document.body.style.background = dark ? "#22222a" : "#f4f7fc";
@@ -391,6 +412,20 @@ export default function App() {
       ...fm,
       symptoms: fm.symptoms.filter((_, i) => i !== idx)
   }));
+
+  const toggleFavoriteFood = (food) => {
+    setFavoriteFoods(favs => {
+      const newSet = favs.includes(food) ? favs.filter(f => f !== food) : [...favs, food];
+      return newSet;
+    });
+  };
+
+  const toggleFavoriteSymptom = (sym) => {
+    setFavoriteSymptoms(favs => {
+      const newSet = favs.includes(sym) ? favs.filter(s => s !== sym) : [...favs, sym];
+      return newSet;
+    });
+  };
 
   const saveEdit = () => {
     if (!editForm) return;
@@ -664,6 +699,13 @@ export default function App() {
         ImgStack={ImgStack}
         CameraButton={CameraButton}
         styles={styles}
+        favoriteFoods={favoriteFoods}
+        favoriteSymptoms={favoriteSymptoms}
+        showFoodQuick={showFoodQuick}
+        setShowFoodQuick={setShowFoodQuick}
+        showSymptomQuick={showSymptomQuick}
+        setShowSymptomQuick={setShowSymptomQuick}
+        QuickMenu={QuickMenu}
       />
       {/* Eintragsliste */}
       <div id="fd-table" style={{position:'relative'}}>
@@ -777,6 +819,10 @@ export default function App() {
             noteDraft={noteDraft}
             setNoteDraft={setNoteDraft}
             saveNote={saveNote}
+            favoriteFoods={favoriteFoods}
+            favoriteSymptoms={favoriteSymptoms}
+            toggleFavoriteFood={toggleFavoriteFood}
+            toggleFavoriteSymptom={toggleFavoriteSymptom}
             SYMPTOM_CHOICES={SYMPTOM_CHOICES}
             TIME_CHOICES={TIME_CHOICES}
             sortSymptomsByTime={sortSymptomsByTime}

--- a/src/App.js
+++ b/src/App.js
@@ -99,6 +99,7 @@ export default function App() {
   });
   const [showFoodQuick, setShowFoodQuick] = useState(false);
   const [showSymptomQuick, setShowSymptomQuick] = useState(false);
+  const [showEditSymptomQuick, setShowEditSymptomQuick] = useState(false);
 
   // keep ref in sync so event handlers see latest state immediately
   useEffect(() => {
@@ -187,6 +188,25 @@ export default function App() {
     document.addEventListener('click', handleOutsideClick);
     return () => document.removeEventListener('click', handleOutsideClick);
   }, [editingIdx]);
+
+  useEffect(() => {
+    const handleQuickClose = (e) => {
+      if (showFoodQuick) {
+        const area = document.getElementById('food-input-container');
+        if (area && !area.contains(e.target)) setShowFoodQuick(false);
+      }
+      if (showSymptomQuick) {
+        const area = document.getElementById('symptom-input-container');
+        if (area && !area.contains(e.target)) setShowSymptomQuick(false);
+      }
+      if (showEditSymptomQuick) {
+        const area = document.getElementById('edit-symptom-input-container');
+        if (area && !area.contains(e.target)) setShowEditSymptomQuick(false);
+      }
+    };
+    document.addEventListener('mousedown', handleQuickClose);
+    return () => document.removeEventListener('mousedown', handleQuickClose);
+  }, [showFoodQuick, showSymptomQuick, showEditSymptomQuick]);
 
   const knownDaysRef = useRef(new Set());
 
@@ -389,10 +409,12 @@ export default function App() {
     });
     setColorPickerOpenForIdx(null);
     setNoteOpenIdx(null);
+    setShowEditSymptomQuick(false);
   };
   const cancelEdit = () => {
     setEditingIdx(null);
     setEditForm(null);
+    setShowEditSymptomQuick(false);
   };
 
   const addEditSymptom = () => {
@@ -411,6 +433,7 @@ export default function App() {
         symptomTime: 0,
         newSymptomStrength: 1
     }));
+    setShowEditSymptomQuick(false);
   };
   const removeEditSymptom = idx => setEditForm(fm => ({
       ...fm,
@@ -832,10 +855,13 @@ export default function App() {
             TAG_COLORS={TAG_COLORS}
             TAG_COLOR_NAMES={TAG_COLOR_NAMES}
             handleFocus={handleFocus}
-                    ImgStack={ImgStack}
-                    CameraButton={CameraButton}
-                    SymTag={SymTag}
-                    styles={styles}
+            ImgStack={ImgStack}
+            CameraButton={CameraButton}
+            SymTag={SymTag}
+            styles={styles}
+            QuickMenu={QuickMenu}
+            showEditSymptomQuick={showEditSymptomQuick}
+            setShowEditSymptomQuick={setShowEditSymptomQuick}
                   />
                 ))}
               </React.Fragment>

--- a/src/components/EntryCard.js
+++ b/src/components/EntryCard.js
@@ -146,6 +146,7 @@ export default function EntryCard({
             <div id="edit-symptom-input-container" style={{ position: 'relative', marginBottom: '8px' }}>
               <input
                 list="symptom-list-edit"
+                className="hide-datalist-arrow"
                 placeholder="Symptom hinzufügen..."
                 value={editForm.symptomInput}
                 onChange={e => setEditForm(fm => ({ ...fm, symptomInput: e.target.value }))}
@@ -161,7 +162,8 @@ export default function EntryCard({
                   position: 'absolute',
                   top: '50%',
                   right: '6px',
-                  transform: 'translateY(-50%)'
+                  transform: 'translateY(-50%)',
+                  color: '#333'
                 }}
                 title="Favoriten"
               >

--- a/src/components/EntryCard.js
+++ b/src/components/EntryCard.js
@@ -185,7 +185,7 @@ export default function EntryCard({
           </div>
 
           <div style={{ marginBottom: 8 }}>
-            {sortSymptomsByTime(editForm.symptoms).map((s, j) => (
+              {sortSymptomsByTime(editForm.symptoms).map((s, j) => (
               <div
                 key={j}
                 style={{ display: 'flex', alignItems: 'center', gap: '6px', marginBottom: '8px', flexWrap: 'nowrap' }}
@@ -205,6 +205,13 @@ export default function EntryCard({
                   onFocus={handleFocus}
                   style={{ ...styles.smallInput, flexGrow: 1, marginRight: '6px' }}
                 />
+                <button
+                  onClick={() => toggleFavoriteSymptom(s.txt)}
+                  title="Favorit"
+                  style={{ background: 'transparent', border: 'none', cursor: 'pointer', fontSize: 18, color: favoriteSymptoms.includes(s.txt) ? '#FBC02D' : '#aaa' }}
+                >
+                  ★
+                </button>
                 <select
                   value={s.time}
                   onChange={e_select =>
@@ -247,13 +254,6 @@ export default function EntryCard({
                   style={{ ...styles.deleteIcon, position: 'static', fontSize: '20px' }}
                 >
                   ×
-                </button>
-                <button
-                  onClick={() => toggleFavoriteSymptom(s.txt)}
-                  title="Favorit"
-                  style={{ background: 'transparent', border: 'none', cursor: 'pointer', fontSize: 18, color: favoriteSymptoms.includes(s.txt) ? '#FBC02D' : '#aaa' }}
-                >
-                  ★
                 </button>
               </div>
             ))}

--- a/src/components/EntryCard.js
+++ b/src/components/EntryCard.js
@@ -114,14 +114,14 @@ export default function EntryCard({
             onChange={e => setEditForm(fm => ({ ...fm, date: e.target.value }))}
             style={{ ...styles.input, marginBottom: '12px', width: '100%' }}
           />
-          <div style={{ display: 'flex', alignItems: 'center', gap: '6px', marginBottom: '8px' }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: '4px', marginBottom: '8px' }}>
             <div id="edit-food-input-container" style={{ position: 'relative', flexGrow: 1 }}>
               <input
                 placeholder="Eintrag..."
                 value={editForm.food}
                 onChange={e => setEditForm(fm => ({ ...fm, food: e.target.value }))}
                 onFocus={handleFocus}
-                style={{ ...styles.input, flexGrow: 1, paddingRight: '30px' }}
+                style={{ ...styles.input, flexGrow: 1, width: '100%', paddingRight: '30px' }}
               />
               <button
                 className="quick-arrow"

--- a/src/components/EntryCard.js
+++ b/src/components/EntryCard.js
@@ -130,7 +130,7 @@ export default function EntryCard({
                   ...styles.glassyIconButton(dark),
                   padding: '4px',
                   position: 'absolute',
-                  top: 'calc(50% - 10px)',
+                  top: 'calc(50% - 5px)',
                   right: '6px',
                   transform: 'translateY(-50%)',
                   color: '#333'
@@ -175,7 +175,6 @@ export default function EntryCard({
           <div style={{ marginBottom: 12 }}>
             <div id="edit-symptom-input-container" style={{ position: 'relative', marginBottom: '8px' }}>
               <input
-                list="symptom-list-edit"
                 className="hide-datalist-arrow"
                 placeholder="Symptom hinzufügen..."
                 value={editForm.symptomInput}
@@ -210,11 +209,6 @@ export default function EntryCard({
                 />
               )}
             </div>
-            <datalist id="symptom-list-edit">
-              {SYMPTOM_CHOICES.map(s => (
-                <option key={s} value={s} />
-              ))}
-            </datalist>
             <div style={{ display: 'flex', alignItems: 'center', gap: '6px', flexWrap: 'nowrap' }}>
               <select
                 value={editForm.symptomTime}
@@ -254,7 +248,6 @@ export default function EntryCard({
               >
                 <input
                   type="text"
-                  list="symptom-list-edit"
                   className="hide-datalist-arrow"
                   value={s.txt}
                   onChange={e_text =>

--- a/src/components/EntryCard.js
+++ b/src/components/EntryCard.js
@@ -46,6 +46,8 @@ export default function EntryCard({
   SymTag,
   styles,
   QuickMenu,
+  showEditFoodQuick,
+  setShowEditFoodQuick,
   showEditSymptomQuick,
   setShowEditSymptomQuick
 }) {
@@ -113,13 +115,41 @@ export default function EntryCard({
             style={{ ...styles.input, marginBottom: '12px', width: '100%' }}
           />
           <div style={{ display: 'flex', alignItems: 'center', gap: '6px', marginBottom: '8px' }}>
-            <input
-              placeholder="Eintrag..."
-              value={editForm.food}
-              onChange={e => setEditForm(fm => ({ ...fm, food: e.target.value }))}
-              onFocus={handleFocus}
-              style={{ ...styles.input, flexGrow: 1 }}
-            />
+            <div id="edit-food-input-container" style={{ position: 'relative', flexGrow: 1 }}>
+              <input
+                placeholder="Eintrag..."
+                value={editForm.food}
+                onChange={e => setEditForm(fm => ({ ...fm, food: e.target.value }))}
+                onFocus={handleFocus}
+                style={{ ...styles.input, width: '100%', paddingRight: '30px' }}
+              />
+              <button
+                className="quick-arrow"
+                onClick={() => setShowEditFoodQuick(s => !s)}
+                style={{
+                  ...styles.glassyIconButton(dark),
+                  padding: '4px',
+                  position: 'absolute',
+                  top: 'calc(50% - 10px)',
+                  right: '6px',
+                  transform: 'translateY(-50%)',
+                  color: '#333'
+                }}
+                title="Favoriten"
+              >
+                ▼
+              </button>
+              {showEditFoodQuick && (
+                <QuickMenu
+                  items={favoriteFoods}
+                  onSelect={f => {
+                    setEditForm(fm => ({ ...fm, food: f }));
+                    setShowEditFoodQuick(false);
+                  }}
+                  style={{ top: '32px', left: 0 }}
+                />
+              )}
+            </div>
             <button
               onClick={() => toggleFavoriteFood(editForm.food.trim())}
               title="Favorit"
@@ -225,6 +255,7 @@ export default function EntryCard({
                 <input
                   type="text"
                   list="symptom-list-edit"
+                  className="hide-datalist-arrow"
                   value={s.txt}
                   onChange={e_text =>
                     setEditForm(fm => ({

--- a/src/components/EntryCard.js
+++ b/src/components/EntryCard.js
@@ -121,7 +121,7 @@ export default function EntryCard({
                 value={editForm.food}
                 onChange={e => setEditForm(fm => ({ ...fm, food: e.target.value }))}
                 onFocus={handleFocus}
-                style={{ ...styles.input, width: '100%', paddingRight: '30px' }}
+                style={{ ...styles.input, flexGrow: 1, paddingRight: '30px' }}
               />
               <button
                 className="quick-arrow"
@@ -130,7 +130,7 @@ export default function EntryCard({
                   ...styles.glassyIconButton(dark),
                   padding: '4px',
                   position: 'absolute',
-                  top: 'calc(50% - 5px)',
+                  top: 'calc(50% - 2px)',
                   right: '6px',
                   transform: 'translateY(-50%)',
                   color: '#333'
@@ -157,8 +157,6 @@ export default function EntryCard({
             >
               ★
             </button>
-          </div>
-          <div style={{ display: 'flex', alignItems: 'center', gap: 8, margin: '8px 0' }}>
             <CameraButton onClick={() => fileRefEdit.current?.click()} />
             <input
               ref={fileRefEdit}

--- a/src/components/EntryCard.js
+++ b/src/components/EntryCard.js
@@ -44,7 +44,10 @@ export default function EntryCard({
   ImgStack,
   CameraButton,
   SymTag,
-  styles
+  styles,
+  QuickMenu,
+  showEditSymptomQuick,
+  setShowEditSymptomQuick
 }) {
   const isSymptomOnlyEntry = !entry.food && (entry.symptoms || []).length > 0;
   const sortedAllDisplay = sortSymptomsByTime(
@@ -140,14 +143,41 @@ export default function EntryCard({
           </div>
 
           <div style={{ marginBottom: 12 }}>
-            <input
-              list="symptom-list-edit"
-              placeholder="Symptom hinzufügen..."
-              value={editForm.symptomInput}
-              onChange={e => setEditForm(fm => ({ ...fm, symptomInput: e.target.value }))}
-              onFocus={handleFocus}
-              style={{ ...styles.smallInput, width: '100%', marginBottom: '8px' }}
-            />
+            <div id="edit-symptom-input-container" style={{ position: 'relative', marginBottom: '8px' }}>
+              <input
+                list="symptom-list-edit"
+                placeholder="Symptom hinzufügen..."
+                value={editForm.symptomInput}
+                onChange={e => setEditForm(fm => ({ ...fm, symptomInput: e.target.value }))}
+                onFocus={handleFocus}
+                style={{ ...styles.smallInput, width: '100%', paddingRight: '30px' }}
+              />
+              <button
+                className="quick-arrow"
+                onClick={() => setShowEditSymptomQuick(s => !s)}
+                style={{
+                  ...styles.glassyIconButton(dark),
+                  padding: '4px',
+                  position: 'absolute',
+                  top: '50%',
+                  right: '6px',
+                  transform: 'translateY(-50%)'
+                }}
+                title="Favoriten"
+              >
+                ▼
+              </button>
+              {showEditSymptomQuick && (
+                <QuickMenu
+                  items={favoriteSymptoms}
+                  onSelect={sym => {
+                    setEditForm(fm => ({ ...fm, symptomInput: sym }));
+                    setShowEditSymptomQuick(false);
+                  }}
+                  style={{ top: '32px', left: 0 }}
+                />
+              )}
+            </div>
             <datalist id="symptom-list-edit">
               {SYMPTOM_CHOICES.map(s => (
                 <option key={s} value={s} />

--- a/src/components/EntryCard.js
+++ b/src/components/EntryCard.js
@@ -31,6 +31,10 @@ export default function EntryCard({
   noteDraft,
   setNoteDraft,
   saveNote,
+  favoriteFoods,
+  favoriteSymptoms,
+  toggleFavoriteFood,
+  toggleFavoriteSymptom,
   SYMPTOM_CHOICES,
   TIME_CHOICES,
   sortSymptomsByTime,
@@ -94,7 +98,7 @@ export default function EntryCard({
             onClick={() => {
               if (window.confirm('Möchten Sie diesen Eintrag wirklich löschen?')) deleteEntry(idx);
             }}
-            style={styles.deleteIcon}
+            style={{ ...styles.buttonSecondary('#d32f2f'), position: 'absolute', bottom: 8, right: 8 }}
             title="Eintrag löschen"
           >
             ×
@@ -105,13 +109,22 @@ export default function EntryCard({
             onChange={e => setEditForm(fm => ({ ...fm, date: e.target.value }))}
             style={{ ...styles.input, marginBottom: '12px', width: '100%' }}
           />
-          <input
-            placeholder="Eintrag..."
-            value={editForm.food}
-            onChange={e => setEditForm(fm => ({ ...fm, food: e.target.value }))}
-            onFocus={handleFocus}
-            style={{ ...styles.input, width: '100%', marginBottom: '8px' }}
-          />
+          <div style={{ display: 'flex', alignItems: 'center', gap: '6px', marginBottom: '8px' }}>
+            <input
+              placeholder="Eintrag..."
+              value={editForm.food}
+              onChange={e => setEditForm(fm => ({ ...fm, food: e.target.value }))}
+              onFocus={handleFocus}
+              style={{ ...styles.input, flexGrow: 1 }}
+            />
+            <button
+              onClick={() => toggleFavoriteFood(editForm.food.trim())}
+              title="Favorit"
+              style={{ background: 'transparent', border: 'none', cursor: 'pointer', fontSize: 20, color: favoriteFoods.includes(editForm.food.trim()) ? '#FBC02D' : '#aaa' }}
+            >
+              ★
+            </button>
+          </div>
           <div style={{ display: 'flex', alignItems: 'center', gap: 8, margin: '8px 0' }}>
             <CameraButton onClick={() => fileRefEdit.current?.click()} />
             <input
@@ -202,7 +215,7 @@ export default function EntryCard({
                       return { ...fm, symptoms: sortSymptomsByTime(updated) };
                     })
                   }
-                  style={{ ...styles.smallInput, width: '37px', flexShrink: 0, fontSize: '16px', padding: '6px 2px' }}
+                  style={{ ...styles.smallInput, width: '22px', flexShrink: 0, fontSize: '16px', padding: '6px 2px' }}
                 >
                   {TIME_CHOICES.map(t => (
                     <option key={t.value} value={t.value}>
@@ -220,7 +233,7 @@ export default function EntryCard({
                       )
                     }))
                   }
-                  style={{ ...styles.smallInput, width: '25px', flexShrink: 0, fontSize: '16px', padding: '6px 2px' }}
+                  style={{ ...styles.smallInput, width: '15px', flexShrink: 0, fontSize: '16px', padding: '6px 2px' }}
                 >
                   {[1, 2, 3].map(n => (
                     <option key={n} value={n}>
@@ -231,9 +244,16 @@ export default function EntryCard({
                 <button
                   onClick={() => removeEditSymptom(j)}
                   title="Symptom löschen"
-                  style={{ ...styles.buttonSecondary('#d32f2f'), padding: '6px 10px', fontSize: 14, flexShrink: 0, lineHeight: '1.2' }}
+                  style={{ ...styles.deleteIcon, position: 'static', fontSize: '20px' }}
                 >
                   ×
+                </button>
+                <button
+                  onClick={() => toggleFavoriteSymptom(s.txt)}
+                  title="Favorit"
+                  style={{ background: 'transparent', border: 'none', cursor: 'pointer', fontSize: 18, color: favoriteSymptoms.includes(s.txt) ? '#FBC02D' : '#aaa' }}
+                >
+                  ★
                 </button>
               </div>
             ))}

--- a/src/components/NewEntryForm.js
+++ b/src/components/NewEntryForm.js
@@ -18,7 +18,6 @@ export default function NewEntryForm({
   dark,
   isMobile,
   handleFocus,
-  SYMPTOM_CHOICES,
   TIME_CHOICES,
   sortSymptomsByTime,
   SymTag,
@@ -35,21 +34,35 @@ export default function NewEntryForm({
 }) {
   return (
     <div className="new-entry-form" style={{ marginBottom: 24 }}>
-      <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 8, position: 'relative' }}>
+      <div style={{ position: 'relative', marginBottom: 8 }}>
         <input
           placeholder="Eintrag..."
           value={newForm.food}
           onChange={e => setNewForm(fm => ({ ...fm, food: e.target.value }))}
           onFocus={handleFocus}
-          style={styles.input}
+          style={{ ...styles.input, paddingRight: '32px' }}
         />
-        <button onClick={() => setShowFoodQuick(s => !s)} style={{ ...styles.glassyIconButton(dark), padding: '6px' }} title="Favoriten">
+        <button
+          onClick={() => setShowFoodQuick(s => !s)}
+          style={{
+            ...styles.glassyIconButton(dark),
+            padding: '4px',
+            position: 'absolute',
+            top: '50%',
+            right: '6px',
+            transform: 'translateY(-50%)'
+          }}
+          title="Favoriten"
+        >
           ▼
         </button>
         {showFoodQuick && (
           <QuickMenu
             items={favoriteFoods}
-            onSelect={item => { setNewForm(fm => ({ ...fm, food: item })); setShowFoodQuick(false); }}
+            onSelect={item => {
+              setNewForm(fm => ({ ...fm, food: item }));
+              setShowFoodQuick(false);
+            }}
             style={{ top: '40px', left: 0 }}
           />
         )}
@@ -69,27 +82,37 @@ export default function NewEntryForm({
       <div style={{ marginTop: newForm.imgs.length > 0 ? 8 : 0, marginBottom: 8 }}>
         <div style={{ position: 'relative', marginBottom: '8px' }}>
           <input
-            list="symptom-list"
             placeholder="Symptom..."
             value={newForm.symptomInput}
             onChange={e => setNewForm(fm => ({ ...fm, symptomInput: e.target.value }))}
             onFocus={handleFocus}
-            style={{ ...styles.smallInput, width: '100%' }}
+            style={{ ...styles.smallInput, width: '100%', paddingRight: '30px' }}
           />
-          <button onClick={() => setShowSymptomQuick(s => !s)} style={{ ...styles.glassyIconButton(dark), padding: '4px', position: 'absolute', right: '-30px', top: 0 }} title="Favoriten">▼</button>
+          <button
+            onClick={() => setShowSymptomQuick(s => !s)}
+            style={{
+              ...styles.glassyIconButton(dark),
+              padding: '4px',
+              position: 'absolute',
+              top: '50%',
+              right: '6px',
+              transform: 'translateY(-50%)'
+            }}
+            title="Favoriten"
+          >
+            ▼
+          </button>
           {showSymptomQuick && (
             <QuickMenu
               items={favoriteSymptoms}
-              onSelect={sym => { setNewForm(fm => ({ ...fm, symptomInput: sym })); setShowSymptomQuick(false); }}
+              onSelect={sym => {
+                setNewForm(fm => ({ ...fm, symptomInput: sym }));
+                setShowSymptomQuick(false);
+              }}
               style={{ top: '32px', left: 0 }}
             />
           )}
         </div>
-        <datalist id="symptom-list">
-          {SYMPTOM_CHOICES.map(s => (
-            <option key={s} value={s} />
-          ))}
-        </datalist>
         <div style={{ display: 'flex', alignItems: 'center', gap: '6px', flexWrap: 'nowrap' }}>
           <select
             value={newForm.symptomTime}

--- a/src/components/NewEntryForm.js
+++ b/src/components/NewEntryForm.js
@@ -49,7 +49,7 @@ export default function NewEntryForm({
             ...styles.glassyIconButton(dark),
             padding: '4px',
             position: 'absolute',
-            top: '50%',
+            top: 'calc(50% - 10px)',
             right: '6px',
             transform: 'translateY(-50%)',
             color: '#333'

--- a/src/components/NewEntryForm.js
+++ b/src/components/NewEntryForm.js
@@ -24,11 +24,18 @@ export default function NewEntryForm({
   SymTag,
   ImgStack,
   CameraButton,
-  styles
+  styles,
+  favoriteFoods,
+  favoriteSymptoms,
+  showFoodQuick,
+  setShowFoodQuick,
+  showSymptomQuick,
+  setShowSymptomQuick,
+  QuickMenu
 }) {
   return (
     <div className="new-entry-form" style={{ marginBottom: 24 }}>
-      <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 8 }}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 8, position: 'relative' }}>
         <input
           placeholder="Eintrag..."
           value={newForm.food}
@@ -36,6 +43,16 @@ export default function NewEntryForm({
           onFocus={handleFocus}
           style={styles.input}
         />
+        <button onClick={() => setShowFoodQuick(s => !s)} style={{ ...styles.glassyIconButton(dark), padding: '6px' }} title="Favoriten">
+          ▼
+        </button>
+        {showFoodQuick && (
+          <QuickMenu
+            items={favoriteFoods}
+            onSelect={item => { setNewForm(fm => ({ ...fm, food: item })); setShowFoodQuick(false); }}
+            style={{ top: '40px', left: 0 }}
+          />
+        )}
         <CameraButton onClick={() => fileRefNew.current?.click()} />
         <input
           ref={fileRefNew}
@@ -50,14 +67,24 @@ export default function NewEntryForm({
       {newForm.imgs.length > 0 && <ImgStack imgs={newForm.imgs} onDelete={removeNewImg} />}
 
       <div style={{ marginTop: newForm.imgs.length > 0 ? 8 : 0, marginBottom: 8 }}>
-        <input
-          list="symptom-list"
-          placeholder="Symptom..."
-          value={newForm.symptomInput}
-          onChange={e => setNewForm(fm => ({ ...fm, symptomInput: e.target.value }))}
-          onFocus={handleFocus}
-          style={{ ...styles.smallInput, width: '100%', marginBottom: '8px' }}
-        />
+        <div style={{ position: 'relative', marginBottom: '8px' }}>
+          <input
+            list="symptom-list"
+            placeholder="Symptom..."
+            value={newForm.symptomInput}
+            onChange={e => setNewForm(fm => ({ ...fm, symptomInput: e.target.value }))}
+            onFocus={handleFocus}
+            style={{ ...styles.smallInput, width: '100%' }}
+          />
+          <button onClick={() => setShowSymptomQuick(s => !s)} style={{ ...styles.glassyIconButton(dark), padding: '4px', position: 'absolute', right: '-30px', top: 0 }} title="Favoriten">▼</button>
+          {showSymptomQuick && (
+            <QuickMenu
+              items={favoriteSymptoms}
+              onSelect={sym => { setNewForm(fm => ({ ...fm, symptomInput: sym })); setShowSymptomQuick(false); }}
+              style={{ top: '32px', left: 0 }}
+            />
+          )}
+        </div>
         <datalist id="symptom-list">
           {SYMPTOM_CHOICES.map(s => (
             <option key={s} value={s} />

--- a/src/components/NewEntryForm.js
+++ b/src/components/NewEntryForm.js
@@ -49,7 +49,7 @@ export default function NewEntryForm({
             ...styles.glassyIconButton(dark),
             padding: '4px',
             position: 'absolute',
-            top: 'calc(50% - 10px)',
+            top: 'calc(50% - 15px)',
             right: '6px',
             transform: 'translateY(-50%)',
             color: '#333'

--- a/src/components/NewEntryForm.js
+++ b/src/components/NewEntryForm.js
@@ -34,15 +34,16 @@ export default function NewEntryForm({
 }) {
   return (
     <div className="new-entry-form" style={{ marginBottom: 24 }}>
-      <div style={{ position: 'relative', marginBottom: 8 }}>
+      <div id="food-input-container" style={{ position: 'relative', marginBottom: 8 }}>
         <input
           placeholder="Eintrag..."
           value={newForm.food}
           onChange={e => setNewForm(fm => ({ ...fm, food: e.target.value }))}
           onFocus={handleFocus}
-          style={{ ...styles.input, paddingRight: '32px' }}
+          style={{ ...styles.input, width: '100%', paddingRight: '32px' }}
         />
         <button
+          className="quick-arrow"
           onClick={() => setShowFoodQuick(s => !s)}
           style={{
             ...styles.glassyIconButton(dark),
@@ -80,26 +81,27 @@ export default function NewEntryForm({
       {newForm.imgs.length > 0 && <ImgStack imgs={newForm.imgs} onDelete={removeNewImg} />}
 
       <div style={{ marginTop: newForm.imgs.length > 0 ? 8 : 0, marginBottom: 8 }}>
-        <div style={{ position: 'relative', marginBottom: '8px' }}>
-          <input
-            placeholder="Symptom..."
-            value={newForm.symptomInput}
-            onChange={e => setNewForm(fm => ({ ...fm, symptomInput: e.target.value }))}
-            onFocus={handleFocus}
-            style={{ ...styles.smallInput, width: '100%', paddingRight: '30px' }}
-          />
-          <button
-            onClick={() => setShowSymptomQuick(s => !s)}
-            style={{
-              ...styles.glassyIconButton(dark),
-              padding: '4px',
-              position: 'absolute',
-              top: '50%',
-              right: '6px',
-              transform: 'translateY(-50%)'
-            }}
-            title="Favoriten"
-          >
+      <div id="symptom-input-container" style={{ position: 'relative', marginBottom: '8px' }}>
+        <input
+          placeholder="Symptom..."
+          value={newForm.symptomInput}
+          onChange={e => setNewForm(fm => ({ ...fm, symptomInput: e.target.value }))}
+          onFocus={handleFocus}
+          style={{ ...styles.smallInput, width: '100%', paddingRight: '30px' }}
+        />
+        <button
+          className="quick-arrow"
+          onClick={() => setShowSymptomQuick(s => !s)}
+          style={{
+            ...styles.glassyIconButton(dark),
+            padding: '4px',
+            position: 'absolute',
+            top: '50%',
+            right: '6px',
+            transform: 'translateY(-50%)'
+          }}
+          title="Favoriten"
+        >
             ▼
           </button>
           {showSymptomQuick && (

--- a/src/components/NewEntryForm.js
+++ b/src/components/NewEntryForm.js
@@ -51,7 +51,8 @@ export default function NewEntryForm({
             position: 'absolute',
             top: '50%',
             right: '6px',
-            transform: 'translateY(-50%)'
+            transform: 'translateY(-50%)',
+            color: '#333'
           }}
           title="Favoriten"
         >
@@ -98,12 +99,13 @@ export default function NewEntryForm({
             position: 'absolute',
             top: '50%',
             right: '6px',
-            transform: 'translateY(-50%)'
+            transform: 'translateY(-50%)',
+            color: '#333'
           }}
           title="Favoriten"
         >
-            ▼
-          </button>
+          ▼
+        </button>
           {showSymptomQuick && (
             <QuickMenu
               items={favoriteSymptoms}

--- a/src/components/NewEntryForm.js
+++ b/src/components/NewEntryForm.js
@@ -49,8 +49,8 @@ export default function NewEntryForm({
             ...styles.glassyIconButton(dark),
             padding: '4px',
             position: 'absolute',
-            top: 'calc(50% - 10px)',
-            right: '46px',
+            top: 'calc(50% - 5px)',
+            right: '48px',
             transform: 'translateY(-50%)',
             color: '#333'
           }}

--- a/src/components/NewEntryForm.js
+++ b/src/components/NewEntryForm.js
@@ -49,7 +49,7 @@ export default function NewEntryForm({
             ...styles.glassyIconButton(dark),
             padding: '4px',
             position: 'absolute',
-            top: 'calc(50% - 5px)',
+            top: 'calc(50% - 2px)',
             right: '48px',
             transform: 'translateY(-50%)',
             color: '#333'

--- a/src/components/NewEntryForm.js
+++ b/src/components/NewEntryForm.js
@@ -34,13 +34,13 @@ export default function NewEntryForm({
 }) {
   return (
     <div className="new-entry-form" style={{ marginBottom: 24 }}>
-      <div id="food-input-container" style={{ position: 'relative', marginBottom: 8 }}>
+      <div id="food-input-container" style={{ position: 'relative', marginBottom: 8, display: 'flex', alignItems: 'center', gap: '6px' }}>
         <input
           placeholder="Eintrag..."
           value={newForm.food}
           onChange={e => setNewForm(fm => ({ ...fm, food: e.target.value }))}
           onFocus={handleFocus}
-          style={{ ...styles.input, width: '100%', paddingRight: '32px' }}
+          style={{ ...styles.input, flexGrow: 1, paddingRight: '32px' }}
         />
         <button
           className="quick-arrow"
@@ -49,7 +49,7 @@ export default function NewEntryForm({
             ...styles.glassyIconButton(dark),
             padding: '4px',
             position: 'absolute',
-            top: 'calc(50% - 15px)',
+            top: 'calc(50% - 18px)',
             right: '6px',
             transform: 'translateY(-50%)',
             color: '#333'

--- a/src/components/NewEntryForm.js
+++ b/src/components/NewEntryForm.js
@@ -49,8 +49,8 @@ export default function NewEntryForm({
             ...styles.glassyIconButton(dark),
             padding: '4px',
             position: 'absolute',
-            top: 'calc(50% - 18px)',
-            right: '6px',
+            top: 'calc(50% - 10px)',
+            right: '46px',
             transform: 'translateY(-50%)',
             color: '#333'
           }}

--- a/src/components/QuickMenu.js
+++ b/src/components/QuickMenu.js
@@ -1,0 +1,22 @@
+import React from 'react';
+
+export default function QuickMenu({ items, onSelect, style }) {
+  return (
+    <div style={{ position: 'absolute', background: '#fff', border: '1px solid #ccc', borderRadius: 4, zIndex: 50, ...style }}>
+      {items.length > 0 ? (
+        items.map(item => (
+          <div
+            key={item}
+            onClick={() => onSelect(item)}
+            style={{ padding: '4px 8px', cursor: 'pointer', whiteSpace: 'nowrap' }}
+          >
+            {item}
+          </div>
+        ))
+      ) : (
+        <div style={{ padding: '4px 8px', color: '#888' }}>Keine Favoriten</div>
+      )}
+    </div>
+  );
+}
+

--- a/src/components/QuickMenu.js
+++ b/src/components/QuickMenu.js
@@ -2,19 +2,22 @@ import React from 'react';
 
 export default function QuickMenu({ items, onSelect, style }) {
   return (
-    <div style={{ position: 'absolute', background: '#fff', border: '1px solid #ccc', borderRadius: 4, zIndex: 50, ...style }}>
+    <div
+      className="quick-menu"
+      style={{ position: 'absolute', background: '#fff', border: '1px solid #ccc', borderRadius: 4, zIndex: 50, ...style }}
+    >
       {items.length > 0 ? (
         items.map(item => (
           <div
             key={item}
             onClick={() => onSelect(item)}
-            style={{ padding: '4px 8px', cursor: 'pointer', whiteSpace: 'nowrap' }}
+            style={{ padding: '4px 8px', cursor: 'pointer', whiteSpace: 'nowrap', color: '#222' }}
           >
             {item}
           </div>
         ))
       ) : (
-        <div style={{ padding: '4px 8px', color: '#888' }}>Keine Favoriten</div>
+        <div style={{ padding: '4px 8px', color: '#444' }}>Keine Favoriten</div>
       )}
     </div>
   );

--- a/src/index.css
+++ b/src/index.css
@@ -20,6 +20,9 @@ input.hide-datalist-arrow {
 input.hide-datalist-arrow::-webkit-calendar-picker-indicator {
   display: none;
 }
+input.hide-datalist-arrow::-webkit-list-button {
+  display: none;
+}
 
 code {
   font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',

--- a/src/index.css
+++ b/src/index.css
@@ -7,6 +7,20 @@ body {
   -moz-osx-font-smoothing: grayscale;
 }
 
+.quick-arrow {
+  color: #333;
+}
+
+input.hide-datalist-arrow {
+  -webkit-appearance: none;
+  -moz-appearance: textfield;
+  appearance: none;
+}
+
+input.hide-datalist-arrow::-webkit-calendar-picker-indicator {
+  display: none;
+}
+
 code {
   font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
     monospace;


### PR DESCRIPTION
## Summary
- add QuickMenu component to show favorite lists
- implement quick menus in the new entry form
- allow starring foods and symptoms in edit mode
- persist favorite items in localStorage
- adjust edit styles for delete buttons and input sizes

## Testing
- `npm test --silent` *(fails: react-scripts not found)*
- `npm run build` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68469c2124e88332bd2bb4fe6cd1eb5d