### PR TITLE
Display only time in EntryCard

### DIFF
--- a/src/components/EntryCard.js
+++ b/src/components/EntryCard.js
@@ -348,7 +348,7 @@ export default function EntryCard({
               color: isExportingPdf ? '#fafafa' : dark ? '#cccccc' : '#444444'
             }}
           >
-            {entry.date}
+            {(entry.date && entry.date.split(' ')[1]) || entry.date}
           </div>
           <div
             style={{


### PR DESCRIPTION
## Summary
- tweak EntryCard to display just the time instead of date and time

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846b8ae25a08332ada268aa2df9f0f2