### PR TITLE
Alphabetize favorites and adjust PDF date color

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -97,16 +97,20 @@ export default function App() {
   const entryRefs = useRef([]);
   const [favoriteFoods, setFavoriteFoods] = useState(() => {
     try {
-      return JSON.parse(localStorage.getItem('fd-fav-foods') || '[]');
+      return JSON.parse(localStorage.getItem('fd-fav-foods') || '[]')
+        .sort((a, b) => a.localeCompare(b));
     } catch { return []; }
   });
   const [favoriteSymptoms, setFavoriteSymptoms] = useState(() => {
     try {
       const stored = JSON.parse(localStorage.getItem('fd-fav-symptoms'));
-      if (stored && Array.isArray(stored) && stored.length > 0) return stored;
-      return SYMPTOM_CHOICES.slice();
+      const arr =
+        stored && Array.isArray(stored) && stored.length > 0
+          ? stored
+          : SYMPTOM_CHOICES.slice();
+      return arr.sort((a, b) => a.localeCompare(b));
     } catch {
-      return SYMPTOM_CHOICES.slice();
+      return SYMPTOM_CHOICES.slice().sort((a, b) => a.localeCompare(b));
     }
   });
   const [showFoodQuick, setShowFoodQuick] = useState(false);
@@ -474,14 +478,14 @@ export default function App() {
   const toggleFavoriteFood = (food) => {
     setFavoriteFoods(favs => {
       const newSet = favs.includes(food) ? favs.filter(f => f !== food) : [...favs, food];
-      return newSet;
+      return newSet.sort((a, b) => a.localeCompare(b));
     });
   };
 
   const toggleFavoriteSymptom = (sym) => {
     setFavoriteSymptoms(favs => {
       const newSet = favs.includes(sym) ? favs.filter(s => s !== sym) : [...favs, sym];
-      return newSet;
+      return newSet.sort((a, b) => a.localeCompare(b));
     });
   };
 

--- a/src/components/EntryCard.js
+++ b/src/components/EntryCard.js
@@ -345,7 +345,13 @@ export default function EntryCard({
               opacity: 0.7,
               marginBottom: 4,
               marginRight: '65px',
-              color: isExportingPdf ? '#fafafa' : dark ? '#cccccc' : '#444444'
+              color: isExportingPdf
+                ? dark
+                  ? '#ffffff'
+                  : '#444444'
+                : dark
+                ? '#cccccc'
+                : '#444444'
             }}
           >
             {(entry.date && entry.date.split(' ')[1]) || entry.date}


### PR DESCRIPTION
## Summary
- keep favorite foods and symptoms sorted alphabetically
- show white date when exporting PDF in dark mode

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846dcbb8bd883328c3b98bbf0c30aa6