### PR TITLE
Fix print connection line alignment

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -332,9 +332,11 @@ export default function App() {
   const handlePrint = async () => {
     const finish = () => setIsPrinting(false);
     const before = () => {
-      window.dispatchEvent(new Event('resize'));
+      setIsPrinting(true);
+      setTimeout(() => {
+        window.dispatchEvent(new Event('resize'));
+      }, 50);
     };
-    setIsPrinting(true);
     window.addEventListener('beforeprint', before, { once: true });
     window.addEventListener('afterprint', finish, { once: true });
     await new Promise(resolve => setTimeout(resolve, 100));

--- a/src/index.css
+++ b/src/index.css
@@ -64,4 +64,8 @@ code {
     break-inside: avoid;
     page-break-inside: avoid;
   }
+  .connection-line {
+    break-inside: avoid;
+    page-break-inside: avoid;
+  }
 }


### PR DESCRIPTION
## Summary
- improve update timing for printing so connection lines are recalculated when print mode activates
- avoid page breaks inside red connection lines

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68473d64a0c88332930bbd46d1485635