### PR TITLE
Fix print connection line alignment

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,5 +1,6 @@
 // --- IMPORTS ---
 import React, { useState, useRef, useEffect } from "react";
+import { flushSync } from 'react-dom';
 
 import useConnections from "./hooks/useConnections";
 import { exportTableToPdf } from "./utils/pdf";
@@ -330,11 +331,14 @@ export default function App() {
   };
 
   const handlePrint = async () => {
-    const finish = () => setIsPrinting(false);
-    const before = () => {
+    const finish = () => {
+      flushSync(() => setIsPrinting(false));
       window.dispatchEvent(new Event('resize'));
     };
-    setIsPrinting(true);
+    const before = () => {
+      flushSync(() => setIsPrinting(true));
+      window.dispatchEvent(new Event('resize'));
+    };
     window.addEventListener('beforeprint', before, { once: true });
     window.addEventListener('afterprint', finish, { once: true });
     await new Promise(resolve => setTimeout(resolve, 100));

--- a/src/index.css
+++ b/src/index.css
@@ -64,4 +64,8 @@ code {
     break-inside: avoid;
     page-break-inside: avoid;
   }
+  .connection-line {
+    break-inside: avoid;
+    page-break-inside: avoid;
+  }
 }


### PR DESCRIPTION
## Summary
- improve update timing for printing so connection lines recalc after flushSync

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68473d64a0c88332930bbd46d1485635