### PR TITLE
Add filter menu and category sorting

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -18,6 +18,7 @@ import Insights from "./components/Insights";
 import NewEntryForm from "./components/NewEntryForm";
 import EntryCard from "./components/EntryCard";
 import QuickMenu from "./components/QuickMenu";
+import FilterMenu from "./components/FilterMenu";
 
 // spacing and sizing for collapsed day indicators
 // slightly smaller rings but still large enough to show counts
@@ -30,6 +31,21 @@ const sortEntries = (a, b) => {
   const dateDiff = parseDateString(b.date) - parseDateString(a.date);
   if (dateDiff !== 0) return dateDiff;
   return (b.createdAt || 0) - (a.createdAt || 0);
+};
+
+const CATEGORY_ORDER = [
+  TAG_COLORS.GREEN,
+  TAG_COLORS.RED,
+  TAG_COLORS.BLUE,
+  TAG_COLORS.BROWN,
+  TAG_COLORS.YELLOW,
+];
+
+const sortEntriesByCategory = (a, b) => {
+  const ca = CATEGORY_ORDER.indexOf(a.tagColor || TAG_COLORS.GREEN);
+  const cb = CATEGORY_ORDER.indexOf(b.tagColor || TAG_COLORS.GREEN);
+  if (ca !== cb) return ca - cb;
+  return sortEntries(a, b);
 };
 // --- HAUPTANWENDUNGSKOMPONENTE: App ---
 export default function App() {
@@ -117,6 +133,9 @@ export default function App() {
   const [showSymptomQuick, setShowSymptomQuick] = useState(false);
   const [showEditFoodQuick, setShowEditFoodQuick] = useState(false);
   const [showEditSymptomQuick, setShowEditSymptomQuick] = useState(false);
+  const [filterTags, setFilterTags] = useState(Object.values(TAG_COLORS));
+  const [filterMenuOpen, setFilterMenuOpen] = useState(false);
+  const [sortMode, setSortMode] = useState('date');
 
   // keep ref in sync so event handlers see latest state immediately
   useEffect(() => {
@@ -224,10 +243,14 @@ export default function App() {
         const area = document.getElementById('edit-symptom-input-container');
         if (area && !area.contains(e.target)) setShowEditSymptomQuick(false);
       }
+      if (filterMenuOpen) {
+        const area = document.getElementById('filter-menu-container');
+        if (area && !area.contains(e.target)) setFilterMenuOpen(false);
+      }
     };
     document.addEventListener('mousedown', handleQuickClose);
     return () => document.removeEventListener('mousedown', handleQuickClose);
-  }, [showFoodQuick, showSymptomQuick, showEditFoodQuick, showEditSymptomQuick]);
+  }, [showFoodQuick, showSymptomQuick, showEditFoodQuick, showEditSymptomQuick, filterMenuOpen]);
 
   const knownDaysRef = useRef(new Set());
 
@@ -258,11 +281,14 @@ export default function App() {
   // Automatisches Nachladen alter Einträge beim Scrollen
   useEffect(() => {
     const handleScroll = () => {
-      const total = entries.filter(e =>
-        (e.food && e.food.toLowerCase().includes(searchTerm.toLowerCase())) ||
-        (e.symptoms || []).some(s => s.txt.toLowerCase().includes(searchTerm.toLowerCase())) ||
-        (e.comment && e.comment.toLowerCase().includes(searchTerm.toLowerCase()))
-      ).length;
+      const total = entries.filter(e => {
+        const matchesSearch =
+          (e.food && e.food.toLowerCase().includes(searchTerm.toLowerCase())) ||
+          (e.symptoms || []).some(s => s.txt.toLowerCase().includes(searchTerm.toLowerCase())) ||
+          (e.comment && e.comment.toLowerCase().includes(searchTerm.toLowerCase()));
+        const matchesFilter = filterTags.includes(e.tagColor || TAG_COLORS.GREEN);
+        return matchesSearch && matchesFilter;
+      }).length;
 
       if (window.innerHeight + window.scrollY >= document.documentElement.scrollHeight - 100) {
         setDisplayCount(dc => dc >= total ? dc : Math.min(dc + 20, total));
@@ -271,7 +297,7 @@ export default function App() {
 
     window.addEventListener('scroll', handleScroll);
     return () => window.removeEventListener('scroll', handleScroll);
-  }, [entries, searchTerm]);
+  }, [entries, searchTerm, filterTags]);
 
   useEffect(() => {
     if (noteOpenIdx !== null) {
@@ -701,13 +727,23 @@ export default function App() {
 
   // --- DATENVORBEREITUNG FÜR DIE ANZEIGE ---
   const filteredWithIdx = entries.map((e, idx) => ({ entry: e, idx }))
-    .filter(({ entry }) =>
-      (entry.food && entry.food.toLowerCase().includes(searchTerm.toLowerCase())) ||
-      (entry.symptoms || []).some(s => s.txt.toLowerCase().includes(searchTerm.toLowerCase())) ||
-      (entry.comment && entry.comment.toLowerCase().includes(searchTerm.toLowerCase()))
-    );
+    .filter(({ entry }) => {
+      const matchesSearch =
+        (entry.food && entry.food.toLowerCase().includes(searchTerm.toLowerCase())) ||
+        (entry.symptoms || []).some(s => s.txt.toLowerCase().includes(searchTerm.toLowerCase())) ||
+        (entry.comment && entry.comment.toLowerCase().includes(searchTerm.toLowerCase()));
+      const matchesFilter = filterTags.includes(entry.tagColor || TAG_COLORS.GREEN);
+      return matchesSearch && matchesFilter;
+    });
 
-  const entriesToRenderForUiOrPdf = (isExportingPdf || isPrinting) ? filteredWithIdx : filteredWithIdx.slice(0, displayCount);
+  const sortedFiltered = filteredWithIdx.slice().sort((a, b) =>
+    sortMode === 'category'
+      ? sortEntriesByCategory(a.entry, b.entry)
+      : sortEntries(a.entry, b.entry)
+  );
+  const entriesToRenderForUiOrPdf = (isExportingPdf || isPrinting)
+    ? sortedFiltered
+    : sortedFiltered.slice(0, displayCount);
 
   const grouped = entriesToRenderForUiOrPdf.reduce((acc, { entry, idx }) => {
     const day = entry.date.split(" ")[0];
@@ -782,6 +818,15 @@ export default function App() {
         showSymptomQuick={showSymptomQuick}
         setShowSymptomQuick={setShowSymptomQuick}
         QuickMenu={QuickMenu}
+        filterTags={filterTags}
+        setFilterTags={setFilterTags}
+        filterMenuOpen={filterMenuOpen}
+        setFilterMenuOpen={setFilterMenuOpen}
+        FilterMenu={FilterMenu}
+        TAG_COLORS={TAG_COLORS}
+        TAG_COLOR_NAMES={TAG_COLOR_NAMES}
+        sortMode={sortMode}
+        setSortMode={setSortMode}
       />
       {/* Eintragsliste */}
       <div id="fd-table" style={{position:'relative'}}>

--- a/src/components/FilterMenu.js
+++ b/src/components/FilterMenu.js
@@ -1,0 +1,45 @@
+import React from 'react';
+
+export default function FilterMenu({ options, selected, onToggle, sortMode, setSortMode, style }) {
+  return (
+    <div
+      className="filter-menu"
+      style={{ position: 'absolute', background: '#fff', border: '1px solid #ccc', borderRadius: 4, zIndex: 50, padding: 4, ...style }}
+    >
+      <div style={{ padding: '4px 8px', borderBottom: '1px solid #ddd', marginBottom: 4 }}>
+        <strong>Sortierung:</strong>
+        <label style={{ marginLeft: 8 }}>
+          <input
+            type="radio"
+            name="sortMode"
+            checked={sortMode === 'date'}
+            onChange={() => setSortMode('date')}
+            style={{ marginRight: 4 }}
+          />
+          Datum
+        </label>
+        <label style={{ marginLeft: 8 }}>
+          <input
+            type="radio"
+            name="sortMode"
+            checked={sortMode === 'category'}
+            onChange={() => setSortMode('category')}
+            style={{ marginRight: 4 }}
+          />
+          Kategorie
+        </label>
+      </div>
+      {options.map(opt => (
+        <label key={opt.value} style={{ display: 'flex', alignItems: 'center', padding: '4px 8px', cursor: 'pointer', whiteSpace: 'nowrap', color: '#222' }}>
+          <input
+            type="checkbox"
+            checked={selected.includes(opt.value)}
+            onChange={() => onToggle(opt.value)}
+            style={{ marginRight: 4 }}
+          />
+          {opt.label}
+        </label>
+      ))}
+    </div>
+  );
+}

--- a/src/components/NewEntryForm.js
+++ b/src/components/NewEntryForm.js
@@ -30,7 +30,16 @@ export default function NewEntryForm({
   setShowFoodQuick,
   showSymptomQuick,
   setShowSymptomQuick,
-  QuickMenu
+  QuickMenu,
+  filterTags,
+  setFilterTags,
+  filterMenuOpen,
+  setFilterMenuOpen,
+  FilterMenu,
+  TAG_COLORS,
+  TAG_COLOR_NAMES,
+  sortMode,
+  setSortMode
 }) {
   return (
     <div className="new-entry-form" style={{ marginBottom: 24 }}>
@@ -173,6 +182,25 @@ export default function NewEntryForm({
             style={{ ...styles.smallInput, flexGrow: 1 }}
           />
         )}
+        <div id="filter-menu-container" style={{ position: 'relative', marginLeft: 'auto' }}>
+          <button
+            onClick={() => setFilterMenuOpen(o => !o)}
+            style={{ ...styles.glassyIconButton(dark), padding: '6px' }}
+            title="Filter"
+          >
+            ⚙️
+          </button>
+          {filterMenuOpen && (
+            <FilterMenu
+              options={Object.values(TAG_COLORS).map(val => ({ value: val, label: TAG_COLOR_NAMES[val] || val }))}
+              selected={filterTags}
+              onToggle={tag => setFilterTags(t => t.includes(tag) ? t.filter(x => x !== tag) : [...t, tag])}
+              sortMode={sortMode}
+              setSortMode={setSortMode}
+              style={{ top: '40px', right: 0 }}
+            />
+          )}
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- enable filtering entries by tag color
- allow sorting entries by category
- add FilterMenu component with sort options
- add filter button to entry form

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684745ed668483329c5e5442f5cd4929