### PR TITLE
Refactor new entry logic into custom hook

### DIFF
--- a/src/hooks/useNewEntryForm.js
+++ b/src/hooks/useNewEntryForm.js
@@ -1,0 +1,103 @@
+import { useState, useRef, useEffect } from 'react';
+import { resizeToJpeg, now, vibrate, determineTagColor, sortSymptomsByTime, sortEntries } from '../utils';
+
+export default function useNewEntryForm(setEntries, addToast) {
+  const [newForm, setNewForm] = useState(() => {
+    const saved = localStorage.getItem('fd-form-new');
+    const initialForm = { food: '', imgs: [], symptomInput: '', symptomTime: 0, symptomStrength: 1 };
+    if (saved) {
+      try {
+        const parsed = JSON.parse(saved);
+        const strength = Math.min(parseInt(parsed.symptomStrength) || 1, 3);
+        return { ...initialForm, ...parsed, symptomStrength: strength };
+      } catch {
+        return initialForm;
+      }
+    }
+    return initialForm;
+  });
+
+  const [newSymptoms, setNewSymptoms] = useState([]);
+  const fileRefNew = useRef();
+  const [showFoodQuick, setShowFoodQuick] = useState(false);
+  const [showSymptomQuick, setShowSymptomQuick] = useState(false);
+
+  useEffect(() => {
+    localStorage.setItem('fd-form-new', JSON.stringify(newForm));
+  }, [newForm]);
+
+  const handleNewFile = async e => {
+    for (let file of Array.from(e.target.files || [])) {
+      try {
+        if (file.size > 5 * 1024 * 1024) throw new Error('Datei zu groß (max 5MB)');
+        const smallB64 = await resizeToJpeg(file, 800);
+        setNewForm(fm => ({ ...fm, imgs: [...fm.imgs, smallB64] }));
+        addToast('Foto hinzugefügt (verkleinert)');
+      } catch (err) {
+        console.error('Fehler beim Hinzufügen des Bildes (neuer Eintrag):', err);
+        addToast(err.message || 'Ungültiges oder zu großes Bild');
+      }
+    }
+    if (e.target) e.target.value = '';
+  };
+
+  const removeNewImg = idx => {
+    setNewForm(fm => ({ ...fm, imgs: fm.imgs.filter((_, i) => i !== idx) }));
+    addToast('Foto gelöscht');
+  };
+
+  const addNewSymptom = () => {
+    if (!newForm.symptomInput.trim()) return;
+    setNewSymptoms(s => sortSymptomsByTime([
+      ...s,
+      { txt: newForm.symptomInput.trim(), time: newForm.symptomTime, strength: newForm.symptomStrength }
+    ]));
+    setNewForm(fm => ({ ...fm, symptomInput: '', symptomTime: 0, symptomStrength: 1 }));
+    vibrate(20);
+  };
+
+  const removeNewSymptom = idx => setNewSymptoms(s => s.filter((_, i) => i !== idx));
+
+  const addEntry = () => {
+    const pendingSymptom = newForm.symptomInput.trim()
+      ? { txt: newForm.symptomInput.trim(), time: newForm.symptomTime, strength: newForm.symptomStrength }
+      : null;
+    const allSymptoms = sortSymptomsByTime([
+      ...newSymptoms,
+      ...(pendingSymptom ? [pendingSymptom] : [])
+    ]);
+    if (!newForm.food.trim() && allSymptoms.length === 0) return;
+    const entry = {
+      food: newForm.food.trim(),
+      imgs: newForm.imgs,
+      symptoms: allSymptoms,
+      comment: '',
+      date: now(),
+      tagColor: determineTagColor(newForm.food.trim(), allSymptoms),
+      tagColorManual: false,
+      linkId: null,
+      createdAt: Date.now(),
+    };
+    setEntries(prev => [...prev, entry].sort(sortEntries));
+    setNewForm({ food: '', imgs: [], symptomInput: '', symptomTime: 0, symptomStrength: 1 });
+    setNewSymptoms([]);
+    addToast('Eintrag gespeichert');
+    vibrate(50);
+  };
+
+  return {
+    newForm,
+    setNewForm,
+    newSymptoms,
+    addNewSymptom,
+    removeNewSymptom,
+    addEntry,
+    handleNewFile,
+    removeNewImg,
+    fileRefNew,
+    showFoodQuick,
+    setShowFoodQuick,
+    showSymptomQuick,
+    setShowSymptomQuick
+  };
+}

--- a/src/utils.js
+++ b/src/utils.js
@@ -131,5 +131,26 @@ const determineTagColor = (food = "", symptoms = []) => {
   return TAG_COLORS.GREEN;
 };
 
+const sortEntries = (a, b) => {
+  const dateDiff = parseDateString(b.date) - parseDateString(a.date);
+  if (dateDiff !== 0) return dateDiff;
+  return (b.createdAt || 0) - (a.createdAt || 0);
+};
 
-export { resizeToJpeg, getStrengthColor, now, vibrate, getTodayDateString, parseDateString, toDateTimePickerFormat, fromDateTimePickerFormat, sortSymptomsByTime, determineTagColor };
+const CATEGORY_ORDER = [
+  TAG_COLORS.GREEN,
+  TAG_COLORS.RED,
+  TAG_COLORS.BLUE,
+  TAG_COLORS.BROWN,
+  TAG_COLORS.YELLOW,
+];
+
+const sortEntriesByCategory = (a, b) => {
+  const ca = CATEGORY_ORDER.indexOf(a.tagColor || TAG_COLORS.GREEN);
+  const cb = CATEGORY_ORDER.indexOf(b.tagColor || TAG_COLORS.GREEN);
+  if (ca !== cb) return ca - cb;
+  return sortEntries(a, b);
+};
+
+
+export { resizeToJpeg, getStrengthColor, now, vibrate, getTodayDateString, parseDateString, toDateTimePickerFormat, fromDateTimePickerFormat, sortSymptomsByTime, determineTagColor, sortEntries, sortEntriesByCategory };


### PR DESCRIPTION
## Summary
- extract diary entry creation logic to `useNewEntryForm` hook
- reuse new hook from `App.js`
- centralize entry sorting helpers in `utils.js`
- fix import order lint error

## Testing
- `npm run build`
- `npm test -- -w 1`


------
https://chatgpt.com/codex/tasks/task_e_6847d72343ec8332b092d8ceeafffe0b