### PR TITLE
Fix PDF export width

### DIFF
--- a/src/utils/pdf.js
+++ b/src/utils/pdf.js
@@ -29,11 +29,19 @@ export async function exportTableToPdf(el) {
     prevBackground = el.style.backgroundColor;
     const bodyBg = getComputedStyle(document.body).backgroundColor;
     el.style.backgroundColor = bodyBg;
+    // Capture a bit more area on each side
+    const extra = 40;
 
     await html2pdf().from(el).set({
       margin: 10,
       filename: 'FoodDiary.pdf',
-      html2canvas: { scale: 2, useCORS: true, backgroundColor: bodyBg },
+      html2canvas: {
+        scale: 2,
+        useCORS: true,
+        backgroundColor: bodyBg,
+        width: el.scrollWidth + extra * 2,
+        x: -extra
+      },
       jsPDF: { unit: 'pt', format: 'a4', orientation: 'portrait' }
     }).save();
     el.style.backgroundColor = prevBackground;


### PR DESCRIPTION
## Summary
- pad PDF capture area so connection lines stay visible
- include width and x offset when capturing via html2canvas

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847eecea9288332929686d89b632e63