### PR TITLE
Fix PDF screenshot capture

### DIFF
--- a/src/utils/pdf.js
+++ b/src/utils/pdf.js
@@ -1,4 +1,5 @@
-import html2pdf from 'html2pdf.js';
+import html2canvas from 'html2canvas';
+import { jsPDF } from 'jspdf';
 
 export async function exportTableToPdf(el) {
   if (!el) return;
@@ -26,16 +27,29 @@ export async function exportTableToPdf(el) {
       img.style.objectFit = 'contain';
     });
 
+
     prevBackground = el.style.backgroundColor;
     const bodyBg = getComputedStyle(document.body).backgroundColor;
     el.style.backgroundColor = bodyBg;
+    // Capture a bit more area on each side
+    const extra = 40;
 
-    await html2pdf().from(el).set({
-      margin: 10,
-      filename: 'FoodDiary.pdf',
-      html2canvas: { scale: 2, useCORS: true, backgroundColor: bodyBg },
-      jsPDF: { unit: 'pt', format: 'a4', orientation: 'portrait' }
-    }).save();
+    const canvas = await html2canvas(el, {
+      scale: 2,
+      useCORS: true,
+      backgroundColor: bodyBg,
+      width: el.scrollWidth + extra * 2,
+      x: -extra,
+    });
+
+    const pdf = new jsPDF({
+      unit: 'px',
+      format: [canvas.width, canvas.height],
+      orientation: 'portrait',
+    });
+    const imgData = canvas.toDataURL('image/png');
+    pdf.addImage(imgData, 'PNG', 0, 0, canvas.width, canvas.height);
+    pdf.save('FoodDiary.pdf');
     el.style.backgroundColor = prevBackground;
     return true;
   } catch (error) {


### PR DESCRIPTION
## Summary
- rewrite PDF export to capture a canvas screenshot
- use html2canvas with extra 40px padding on each side

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847eecea9288332929686d89b632e63