### PR TITLE
Fix print alignment for connections

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -337,7 +337,7 @@ export default function App() {
     setIsPrinting(true);
     window.addEventListener('beforeprint', before, { once: true });
     window.addEventListener('afterprint', finish, { once: true });
-    await new Promise(resolve => setTimeout(resolve, 100));
+    await new Promise(resolve => setTimeout(resolve, 300));
     window.print();
   };
 

--- a/src/hooks/useConnections.js
+++ b/src/hooks/useConnections.js
@@ -63,9 +63,13 @@ export default function useConnections(entries, searchTerm, displayCount, collap
     updateConnections();
     window.addEventListener('scroll', updateConnections);
     window.addEventListener('resize', updateConnections);
+    window.addEventListener('beforeprint', updateConnections);
+    window.addEventListener('afterprint', updateConnections);
     return () => {
       window.removeEventListener('scroll', updateConnections);
       window.removeEventListener('resize', updateConnections);
+      window.removeEventListener('beforeprint', updateConnections);
+      window.removeEventListener('afterprint', updateConnections);
     };
   }, [entries, searchTerm, displayCount, collapsedDays, extraFlag]);
 


### PR DESCRIPTION
## Summary
- adjust connections when printing by recalculating on `beforeprint`
- wait longer before starting print so DOM settles

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848149e06d48332b74265173ad498c0