### PR TITLE
Fix PDF export clipping

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -742,7 +742,14 @@ export default function App() {
         setSortMode={setSortMode}
       />
       {/* Eintragsliste */}
-      <div id="fd-table" style={{position:'relative'}}>
+      <div id="fd-table" style={{
+        position: 'relative',
+        ...(isExportingPdf || isPrinting ? {
+          paddingLeft: '60px',
+          marginLeft: '-60px',
+          boxSizing: 'border-box',
+        } : {})
+      }}>
         <ConnectionLines
           connections={connections}
           styles={styles}


### PR DESCRIPTION
## Summary
- adjust inline styles for `fd-table` during export and print to prevent lines from being clipped

## Testing
- `npm test --silent` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68482048e0608332a9e9fa23a3a31a16