### PR TITLE
Fix PDF export container

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -80,6 +80,7 @@ export default function App() {
   const linkingInfoRef = useRef(null);
   const containerRef = useRef(null);
   const entryRefs = useRef([]);
+  const exportContainerRef = useRef(null);
   const [favoriteFoods, setFavoriteFoods] = useState(() => {
     try {
       return JSON.parse(localStorage.getItem('fd-fav-foods') || '[]')
@@ -313,7 +314,7 @@ export default function App() {
   };
 
   const handleExportPDF = async () => {
-    const el = document.getElementById("fd-table");
+    const el = exportContainerRef.current;
     if (!el) return;
 
     setColorPickerOpenForIdx(null);
@@ -321,7 +322,7 @@ export default function App() {
 
     addToast("PDF Export wird vorbereitet...");
     setIsExportingPdf(true);
-    await new Promise(resolve => setTimeout(resolve, 300));
+    await new Promise(resolve => setTimeout(resolve, 1000));
 
     const ok = await exportTableToPdf(el);
     if (ok) addToast("PDF erfolgreich exportiert!");
@@ -742,12 +743,27 @@ export default function App() {
         setSortMode={setSortMode}
       />
       {/* Eintragsliste */}
-      <div id="fd-table" style={{position:'relative'}}>
-        <ConnectionLines
-          connections={connections}
-          styles={styles}
-          handleConnectionClick={handleConnectionClick}
-        />
+      <div id="export-container" ref={exportContainerRef}>
+
+        <div 
+          id="fd-table" 
+          style={{
+            position: 'relative',
+            ...( (isExportingPdf || isPrinting) && {
+              transform: 'translateX(60px)',
+            })
+          }}>
+          <ConnectionLines
+            connections={connections}
+            styles={{
+              ...styles,
+              connectionSvg: {
+                ...styles.connectionSvg,
+                zIndex: (isExportingPdf || isPrinting) ? 9999 : 'auto',
+              },
+            }}
+            handleConnectionClick={handleConnectionClick}
+          />
         {dates.map(day => (
           <DayGroup
             key={day}
@@ -815,6 +831,7 @@ export default function App() {
             dayMarkTop={DAY_MARK_TOP}
           />
         ))}
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- add exportContainerRef for PDF export
- wrap `#fd-table` with an outer `export-container` div for proper layout
- adjust export function to use the wrapper element
- shift inner table with `transform` instead of margin during export/print
- bump PDF export delay to 1000ms and enforce z-index for connection lines

## Testing
- `npm install`
- `npm test --silent` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_684827efd27c8332ab64c256e353b63b