### PR TITLE
Fix PDF export to show red lines

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,6 @@
         "@testing-library/react": "^16.3.0",
         "@testing-library/user-event": "^13.5.0",
         "html2canvas": "^1.4.1",
-        "html2pdf.js": "^0.10.3",
         "jspdf": "^3.0.1",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
@@ -7179,12 +7178,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/es6-promise": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
-      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
-      "license": "MIT"
-    },
     "node_modules/escalade": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
@@ -9090,17 +9083,6 @@
       },
       "engines": {
         "node": ">=8.0.0"
-      }
-    },
-    "node_modules/html2pdf.js": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/html2pdf.js/-/html2pdf.js-0.10.3.tgz",
-      "integrity": "sha512-RcB1sh8rs5NT3jgbN5zvvTmkmZrsUrxpZ/RI8TMbvuReNZAdJZG5TMfA2TBP6ZXxpXlWf9NB/ciLXVb6W2LbRQ==",
-      "license": "MIT",
-      "dependencies": {
-        "es6-promise": "^4.2.5",
-        "html2canvas": "^1.0.0",
-        "jspdf": "^3.0.0"
       }
     },
     "node_modules/htmlparser2": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
     "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^13.5.0",
     "html2canvas": "^1.4.1",
-    "html2pdf.js": "^0.10.3",
     "jspdf": "^3.0.1",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",

--- a/src/utils/pdf.js
+++ b/src/utils/pdf.js
@@ -1,7 +1,8 @@
-import html2pdf from 'html2pdf.js';
+import html2canvas from 'html2canvas';
+import jsPDF from 'jspdf';
 
 export async function exportTableToPdf(el) {
-  if (!el) return;
+  if (!el) return false;
 
   const imgStackItemOriginalStyles = [];
   const individualImageOriginalStyles = [];
@@ -30,13 +31,26 @@ export async function exportTableToPdf(el) {
     const bodyBg = getComputedStyle(document.body).backgroundColor;
     el.style.backgroundColor = bodyBg;
 
-    await html2pdf().from(el).set({
-      margin: 10,
-      filename: 'FoodDiary.pdf',
-      html2canvas: { scale: 2, useCORS: true, backgroundColor: bodyBg },
-      jsPDF: { unit: 'pt', format: 'a4', orientation: 'portrait' }
-    }).save();
-    el.style.backgroundColor = prevBackground;
+    const canvas = await html2canvas(el, {
+      scale: 2,
+      useCORS: true,
+      backgroundColor: bodyBg,
+      scrollX: 0,
+      scrollY: -window.scrollY,
+      windowWidth: document.documentElement.scrollWidth,
+      windowHeight: document.documentElement.scrollHeight
+    });
+
+    const imgData = canvas.toDataURL('image/png');
+    const pdf = new jsPDF({
+      orientation: 'portrait',
+      unit: 'px',
+      format: [canvas.width, canvas.height]
+    });
+
+    pdf.addImage(imgData, 'PNG', 0, 0, canvas.width, canvas.height);
+    pdf.save('FoodDiary.pdf');
+
     return true;
   } catch (error) {
     console.error('Fehler beim Erstellen des PDFs:', error);


### PR DESCRIPTION
## Summary
- switch PDF generation to use html2canvas and jsPDF instead of html2pdf
- drop unused html2pdf.js dependency

## Testing
- `CI=true npm test --silent -- --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_6848369e44048332b6e26effece02602