### PR TITLE
Adjust entry card width and position

### DIFF
--- a/src/styles.js
+++ b/src/styles.js
@@ -81,7 +81,8 @@ const styles = {
   entryCard: (dark, isSymptomOnly = false) => ({
     position: 'relative',
     marginBottom: 16,
-    marginLeft: 5,
+    marginLeft: 10, // moved 5px to the right for connection line space
+    marginRight: 5,
     padding: 12,
     borderRadius: 8,
     background: isSymptomOnly


### PR DESCRIPTION
## Summary
- give entry cards extra left and right margin
- shift cards to the right slightly for connection line space

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684840105b18833284ae4d3105fde959