### PR TITLE
Adjust PDF export to screenshot entire app

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -2,7 +2,7 @@
 import React, { useState, useRef, useEffect } from "react";
 
 import useConnections from "./hooks/useConnections";
-import { exportTableToPdf } from "./utils/pdf";
+import { exportTableToPdf, exportAppScreenshotToPdf } from "./utils/pdf";
 
 import styles from "./styles";
 import { SYMPTOM_CHOICES, TIME_CHOICES, TAG_COLORS, TAG_COLOR_NAMES } from "./constants";
@@ -313,7 +313,7 @@ export default function App() {
   };
 
   const handleExportPDF = async () => {
-    const el = document.getElementById("fd-table");
+    const el = document.getElementById("root");
     if (!el) return;
 
     setColorPickerOpenForIdx(null);
@@ -323,7 +323,7 @@ export default function App() {
     setIsExportingPdf(true);
     await new Promise(resolve => setTimeout(resolve, 300));
 
-    const ok = await exportTableToPdf(el);
+    const ok = await exportAppScreenshotToPdf(el);
     if (ok) addToast("PDF erfolgreich exportiert!");
     else addToast("Fehler beim PDF-Export.");
     setIsExportingPdf(false);

--- a/src/utils/pdf.js
+++ b/src/utils/pdf.js
@@ -1,4 +1,6 @@
 import html2pdf from 'html2pdf.js';
+import html2canvas from 'html2canvas';
+import { jsPDF } from 'jspdf';
 
 export async function exportTableToPdf(el) {
   if (!el) return;
@@ -52,5 +54,20 @@ export async function exportTableToPdf(el) {
       orig.el.style.objectFit = orig.objectFit;
     });
     if (prevBackground) el.style.backgroundColor = prevBackground;
+  }
+}
+
+export async function exportAppScreenshotToPdf(el) {
+  if (!el) return false;
+  try {
+    const canvas = await html2canvas(el, { scale: 2, useCORS: true });
+    const imgData = canvas.toDataURL('image/png');
+    const pdf = new jsPDF({ unit: 'px', format: [canvas.width, canvas.height], orientation: 'portrait' });
+    pdf.addImage(imgData, 'PNG', 0, 0, canvas.width, canvas.height);
+    pdf.save('FoodDiary.pdf');
+    return true;
+  } catch (err) {
+    console.error('Fehler beim Erstellen des Screenshot-PDFs:', err);
+    return false;
   }
 }


### PR DESCRIPTION
## Summary
- revert extra margins on entry cards
- add new `exportAppScreenshotToPdf` helper
- export a screenshot of the whole app instead of the entries

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684840105b18833284ae4d3105fde959