### PR TITLE
Fix export and print timing

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -316,29 +316,39 @@ export default function App() {
     const el = document.getElementById("fd-table");
     if (!el) return;
 
-    setColorPickerOpenForIdx(null);
-    setNoteOpenIdx(null);
-
     addToast("PDF Export wird vorbereitet...");
-    setIsExportingPdf(true);
-    await new Promise(resolve => setTimeout(resolve, 300));
 
+    // 1. Export-Modus aktivieren
+    // Dies sorgt dafür, dass alle Einträge gerendert werden.
+    setIsExportingPdf(true);
+
+    // 2. WICHTIG: Kurze Pause erzwingen
+    // Gib dem Browser und React einen Moment Zeit, das Layout neu zu zeichnen
+    // und die Linienpositionen im useConnections-Hook mit den neuen,
+    // korrekten Koordinaten zu aktualisieren.
+    await new Promise(resolve => setTimeout(resolve, 100)); // 100ms ist ein sicherer Wert
+
+    // 3. Jetzt, wo alles an der richtigen Position ist, den Export starten
     const ok = await exportTableToPdf(el);
     if (ok) addToast("PDF erfolgreich exportiert!");
     else addToast("Fehler beim PDF-Export.");
+
+    // 4. Aufräumen und den Export-Modus beenden
     setIsExportingPdf(false);
   };
 
   const handlePrint = async () => {
-    const finish = () => setIsPrinting(false);
-    const before = () => {
-      window.dispatchEvent(new Event('resize'));
-    };
+    // 1. Druck-Modus aktivieren
     setIsPrinting(true);
-    window.addEventListener('beforeprint', before, { once: true });
-    window.addEventListener('afterprint', finish, { once: true });
+
+    // 2. WICHTIG: Auch hier die kurze Pause erzwingen
     await new Promise(resolve => setTimeout(resolve, 100));
+
+    // 3. Jetzt das Druckfenster öffnen
     window.print();
+
+    // Dein 'afterprint' Event-Listener wird setIsPrinting(false)
+    // nach dem Drucken aufrufen, was perfekt ist.
   };
 
   const handleEditFile = async e => {

--- a/src/App.js
+++ b/src/App.js
@@ -338,17 +338,21 @@ export default function App() {
   };
 
   const handlePrint = async () => {
+    const finish = () => setIsPrinting(false);
+    const before = () => {
+      window.dispatchEvent(new Event('resize'));
+    };
+
     // 1. Druck-Modus aktivieren
     setIsPrinting(true);
+    window.addEventListener('beforeprint', before, { once: true });
+    window.addEventListener('afterprint', finish, { once: true });
 
     // 2. WICHTIG: Auch hier die kurze Pause erzwingen
     await new Promise(resolve => setTimeout(resolve, 100));
 
     // 3. Jetzt das Druckfenster öffnen
     window.print();
-
-    // Dein 'afterprint' Event-Listener wird setIsPrinting(false)
-    // nach dem Drucken aufrufen, was perfekt ist.
   };
 
   const handleEditFile = async e => {


### PR DESCRIPTION
## Summary
- update `handleExportPDF` to wait before capturing snapshot for PDF
- simplify `handlePrint` with a short delay before printing

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684853510b508332874847de030e78df