### PR TITLE
Fix export layout with wrapper groups

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -316,16 +316,24 @@ export default function App() {
     const el = document.getElementById("fd-table");
     if (!el) return;
 
-    setColorPickerOpenForIdx(null);
-    setNoteOpenIdx(null);
-
     addToast("PDF Export wird vorbereitet...");
-    setIsExportingPdf(true);
-    await new Promise(resolve => setTimeout(resolve, 300));
 
+    // 1. Export-Modus aktivieren
+    // Dies sorgt dafür, dass alle Einträge gerendert werden.
+    setIsExportingPdf(true);
+
+    // 2. WICHTIG: Kurze Pause erzwingen
+    // Gib dem Browser und React einen Moment Zeit, das Layout neu zu zeichnen
+    // und die Linienpositionen im useConnections-Hook mit den neuen,
+    // korrekten Koordinaten zu aktualisieren.
+    await new Promise(resolve => setTimeout(resolve, 100)); // 100ms ist ein sicherer Wert
+
+    // 3. Jetzt, wo alles an der richtigen Position ist, den Export starten
     const ok = await exportTableToPdf(el);
     if (ok) addToast("PDF erfolgreich exportiert!");
     else addToast("Fehler beim PDF-Export.");
+
+    // 4. Aufräumen und den Export-Modus beenden
     setIsExportingPdf(false);
   };
 
@@ -334,10 +342,16 @@ export default function App() {
     const before = () => {
       window.dispatchEvent(new Event('resize'));
     };
+
+    // 1. Druck-Modus aktivieren
     setIsPrinting(true);
     window.addEventListener('beforeprint', before, { once: true });
     window.addEventListener('afterprint', finish, { once: true });
+
+    // 2. WICHTIG: Auch hier die kurze Pause erzwingen
     await new Promise(resolve => setTimeout(resolve, 100));
+
+    // 3. Jetzt das Druckfenster öffnen
     window.print();
   };
 
@@ -744,17 +758,20 @@ export default function App() {
       {/* Eintragsliste */}
       <div
         id="fd-table"
+        className={isExportingPdf || isPrinting ? 'export-mode' : ''}
         style={{
           position: 'relative',
           marginLeft: -(maxLane * 5),
           width: `calc(100% + ${maxLane * 5}px)`,
         }}
       >
-        <ConnectionLines
-          connections={connections}
-          styles={styles}
-          handleConnectionClick={handleConnectionClick}
-        />
+        {!(isExportingPdf || isPrinting) && (
+          <ConnectionLines
+            connections={connections}
+            styles={styles}
+            handleConnectionClick={handleConnectionClick}
+          />
+        )}
         {dates.map(day => (
           <DayGroup
             key={day}

--- a/src/components/DayGroup.js
+++ b/src/components/DayGroup.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import EntryCard from './EntryCard';
+import { groupEntriesByLink } from '../utils';
 
 export default function DayGroup({
   day,
@@ -31,6 +32,8 @@ export default function DayGroup({
     TAG_COLORS.BROWN,
     TAG_COLORS.YELLOW,
   ].filter(c => colorCounts[c]);
+
+  const entryConnectionGroups = groupEntriesByLink(entries);
 
   return (
     <div>
@@ -66,7 +69,7 @@ export default function DayGroup({
         </div>
       ) : (
         <React.Fragment>
-          <div onClick={() => toggleDay(day)} style={styles.groupHeader(isExportingPdf)}>
+          <div onClick={() => toggleDay(day)} style={styles.groupHeader(isExportingPdf || isPrinting)}>
             <button
               onClick={e => { e.stopPropagation(); toggleDay(day); }}
               style={styles.collapseButton(dark)}
@@ -76,14 +79,33 @@ export default function DayGroup({
             </button>
             {day}
           </div>
-          {entries.map(({ entry, idx }) => (
-            <EntryCard
-              key={idx}
-              refCallback={el => (entryRefs.current[idx] = el)}
-              entry={entry}
-              idx={idx}
-              {...entryCardProps}
-            />
+          {entryConnectionGroups.map((group, groupIndex) => (
+            group.length > 1 ? (
+              <div
+                key={group[0].entry.linkId || `group-${groupIndex}`}
+                className="connection-group"
+              >
+                {group.map(({ entry, idx }) => (
+                  <EntryCard
+                    key={idx}
+                    refCallback={el => (entryRefs.current[idx] = el)}
+                    entry={entry}
+                    idx={idx}
+                    {...entryCardProps}
+                  />
+                ))}
+              </div>
+            ) : (
+              group.length === 1 && (
+                <EntryCard
+                  key={group[0].idx}
+                  refCallback={el => (entryRefs.current[group[0].idx] = el)}
+                  entry={group[0].entry}
+                  idx={group[0].idx}
+                  {...entryCardProps}
+                />
+              )
+            )
           ))}
         </React.Fragment>
       )}

--- a/src/components/EntryCard.js
+++ b/src/components/EntryCard.js
@@ -69,6 +69,7 @@ export default function EntryCard({
     <div
       ref={refCallback}
       id={`entry-card-${idx}`}
+      className="entry-card"
       style={styles.entryCard(dark, isSymptomOnlyEntry)}
       onClick={e => {
         if (isExportingPdf) return;

--- a/src/index.css
+++ b/src/index.css
@@ -47,6 +47,49 @@ code {
 }
 
 
+/* Verstecke die alten, per JS gezeichneten Linien im Export */
+.export-mode .connection-lines-container {
+  display: none !important;
+}
+
+/* Der Wrapper für eine verbundene Gruppe */
+.export-mode .connection-group {
+  position: relative;
+  padding-left: 20px; 
+  break-inside: avoid;
+  page-break-inside: avoid;
+}
+
+/* 1. Die VERTIKALE Hauptlinie (wie bisher, aber mit wichtigerem z-index) */
+.export-mode .connection-group::before {
+  content: '';
+  position: absolute;
+  background-color: #d32f2f;
+  width: 2px;
+  left: 5px; 
+  top: 30px; 
+  bottom: 30px;
+  z-index: 1; /* Stellt sicher, dass die Hauptlinie hinter den Verbindern liegt */
+}
+
+/* 2. NEU: Der HORIZONTALE Verbinder-Arm für JEDEN Eintrag in der Gruppe */
+/* Wir stylen hier die EntryCard-Komponente selbst, wenn sie im Wrapper ist */
+.export-mode .connection-group .entry-card {
+  position: relative; /* Wichtig für die Positionierung des Pseudo-Elements */
+}
+
+.export-mode .connection-group .entry-card::before {
+  content: '';
+  position: absolute;
+  background-color: #d32f2f;
+  height: 2px;   /* Höhe der horizontalen Linie */
+  width: 15px;   /* Länge der horizontalen Linie */
+  left: -14px;  /* Positioniert den Arm von der Kante der Karte nach links */
+  top: 25px;     /* Vertikale Position des Arms - MUSS ZUM PIN-ICON PASSEN */
+  z-index: 2;
+}
+
+
 @media print {
   body {
     -webkit-print-color-adjust: exact;

--- a/src/utils.js
+++ b/src/utils.js
@@ -152,5 +152,32 @@ const sortEntriesByCategory = (a, b) => {
   return sortEntries(a, b);
 };
 
+// Gruppiert Tageinträge nach ihrer Link-ID, sortiert nach Index
+// und gibt eine Liste von Gruppen zurück. Einzelne Einträge werden
+// als Gruppe mit einem Element behandelt.
+function groupEntriesByLink(dayEntries) {
+  if (!dayEntries || dayEntries.length === 0) return [];
 
-export { resizeToJpeg, getStrengthColor, now, vibrate, getTodayDateString, parseDateString, toDateTimePickerFormat, fromDateTimePickerFormat, sortSymptomsByTime, determineTagColor, sortEntries, sortEntriesByCategory };
+  const linkGroups = new Map();
+  const singleEntries = [];
+
+  for (const entry of dayEntries) {
+    if (entry.entry.linkId) {
+      if (!linkGroups.has(entry.entry.linkId)) {
+        linkGroups.set(entry.entry.linkId, []);
+      }
+      linkGroups.get(entry.entry.linkId).push(entry);
+    } else {
+      singleEntries.push([entry]);
+    }
+  }
+
+  const linked = Array.from(linkGroups.values());
+  const allGroups = [...singleEntries, ...linked];
+  allGroups.sort((a, b) => a[0].idx - b[0].idx);
+
+  return allGroups;
+}
+
+
+export { resizeToJpeg, getStrengthColor, now, vibrate, getTodayDateString, parseDateString, toDateTimePickerFormat, fromDateTimePickerFormat, sortSymptomsByTime, determineTagColor, sortEntries, sortEntriesByCategory, groupEntriesByLink };


### PR DESCRIPTION
## Summary
- group daily entries by link ID so export can add wrapper containers
- hide connection lines when exporting or printing
- add export-mode styling for grouped entries
- ensure main table toggles export mode class
- refine export CSS and add `entry-card` class for wrapper styling

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684853510b508332874847de030e78df