### PR TITLE
Refactor connection lines rendering

### DIFF
--- a/src/components/ConnectionLines.js
+++ b/src/components/ConnectionLines.js
@@ -1,61 +1,58 @@
 import React from 'react';
 
 export default function ConnectionLines({ connections, styles, handleConnectionClick }) {
+  if (!connections || connections.length === 0) {
+    return null;
+  }
+
+  // Calculate the total size needed for the SVG canvas
+  const maxBottom = Math.max(...connections.map(c => c.bottom), 0);
+  const maxLane = Math.max(...connections.map(c => c.lane), 0);
+  const svgWidth = 25 + (maxLane * 5); // Give it a little padding
+
   return (
-    <>
+    <svg
+      width={svgWidth}
+      height={maxBottom}
+      style={{ ...styles.connectionSvg, position: 'absolute', top: 0, left: 0, overflow: 'visible' }}
+      xmlns="http://www.w3.org/2000/svg"
+    >
       {connections.map(c => {
-        const offset = -c.lane * 5;
-        const height = c.bottom - c.top;
-        const horizWidth = 10 - offset;
+        // Calculate the X position for the vertical line based on its lane
+        // We draw from left to right. Lane 0 is furthest left.
+        const verticalLineX = 15 - (c.lane * 5);
+        const stubEndX = verticalLineX + 8;
+
+        // Use a single SVG <path> element to draw everything for one connection.
+        // 'M' is "move to", 'L' is "line to".
+        let pathData = ``;
+        // Main vertical line
+        pathData += `M ${verticalLineX} ${c.top} L ${verticalLineX} ${c.bottom} `;
+        // Top horizontal stub
+        pathData += `M ${verticalLineX} ${c.top} L ${stubEndX} ${c.top} `;
+        // Bottom horizontal stub
+        pathData += `M ${verticalLineX} ${c.bottom} L ${stubEndX} ${c.bottom} `;
+
+        // Add stubs for any intermediate "crossed" entries
+        c.cross.forEach(crossPointY => {
+          // The 'y' in cross is an offset from the top of the connection line
+          const absoluteY = c.top + crossPointY;
+          pathData += `M ${verticalLineX} ${absoluteY} L ${stubEndX} ${absoluteY} `;
+        });
+
         return (
-          <div
+          <path
             key={c.id}
-            className="connection-line"
+            d={pathData}
+            stroke="#b22222"
+            strokeWidth="2"
+            strokeDasharray="4 3"
+            fill="none"
             onClick={e => { e.stopPropagation(); handleConnectionClick(c.id); }}
-            style={{ ...styles.connectionSvg, top: c.top, height }}
-          >
-            <div
-              style={{
-                position: 'absolute',
-                left: offset,
-                top: 0,
-                bottom: 0,
-                borderLeft: '2px dashed #b22222',
-              }}
-            />
-            <div
-              style={{
-                position: 'absolute',
-                left: offset,
-                top: 0,
-                width: horizWidth,
-                borderTop: '2px dashed #b22222',
-              }}
-            />
-            <div
-              style={{
-                position: 'absolute',
-                left: offset,
-                bottom: 0,
-                width: horizWidth,
-                borderTop: '2px dashed #b22222',
-              }}
-            />
-            {c.cross.map(y => (
-              <div
-                key={y}
-                style={{
-                  position: 'absolute',
-                  left: offset,
-                  top: y,
-                  width: horizWidth,
-                  borderTop: '2px dashed #b22222',
-                }}
-              />
-            ))}
-          </div>
+            style={{ cursor: 'pointer' }}
+          />
         );
       })}
-    </>
+    </svg>
   );
 }

--- a/src/hooks/useConnections.js
+++ b/src/hooks/useConnections.js
@@ -62,14 +62,26 @@ export default function useConnections(entries, searchTerm, displayCount, collap
       setConnections(sortedConns);
       setMaxLane(sortedConns.reduce((m, c) => Math.max(m, c.lane), 0));
     };
-    updateConnections();
-    window.addEventListener('scroll', updateConnections);
-    window.addEventListener('resize', updateConnections);
-    return () => {
-      window.removeEventListener('scroll', updateConnections);
-      window.removeEventListener('resize', updateConnections);
-    };
-  }, [entries, searchTerm, displayCount, collapsedDays, extraFlag]);
+
+    // --- THIS IS THE MODIFIED LOGIC ---
+    if (extraFlag) {
+      // IN EXPORT MODE:
+      // We wait for the next animation frame. This gives the browser time to complete
+      // its layout calculations for all the newly rendered entries before we measure.
+      const animationFrameId = requestAnimationFrame(updateConnections);
+      return () => cancelAnimationFrame(animationFrameId);
+    } else {
+      // IN LIVE MODE:
+      // The original behavior is fine for scrolling and resizing.
+      updateConnections(); // Initial update
+      window.addEventListener('scroll', updateConnections);
+      window.addEventListener('resize', updateConnections);
+      return () => {
+        window.removeEventListener('scroll', updateConnections);
+        window.removeEventListener('resize', updateConnections);
+      };
+    }
+  }, [entries, searchTerm, displayCount, collapsedDays, entryRefs, extraFlag]);
 
   return { connections, maxLane };
 }


### PR DESCRIPTION
## Summary
- render connection lines via SVG paths
- simplify fd-table layout now that lines handle their own spacing

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848665c20108332bc56d989ac76bc2b