### PR TITLE
Maintain entry order for link groups

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -775,15 +775,27 @@ export default function App() {
 
   const grouped = Object.fromEntries(
     Object.entries(perDay).map(([day, { all, groups }]) => {
-      const multiIds = Object.keys(groups)
-        .filter(id => groups[id].length >= 2)
-        .map(id => Number(id))
-        .sort((a,b) => b - a);
-      const normal = all.filter(({ entry }) => {
-        const id = entry.linkId;
-        return !id || groups[id].length === 1;
-      });
-      const list = [...normal, ...multiIds.flatMap(id => groups[id])];
+      const multiIds = new Set(
+        Object.keys(groups)
+          .filter(id => groups[id].length >= 2)
+          .map(id => Number(id))
+      );
+
+      const added = new Set();
+      const list = [];
+
+      for (const item of all) {
+        const id = item.entry.linkId;
+        if (id && multiIds.has(id)) {
+          if (!added.has(id)) {
+            list.push(...groups[id]);
+            added.add(id);
+          }
+        } else {
+          list.push(item);
+        }
+      }
+
       return [day, { list, groups }];
     })
   );


### PR DESCRIPTION
## Summary
- modify grouping logic so linked entries keep their chronological position

## Testing
- `CI=true npm test --silent -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68497cb815f0833292972254a6f5d191