### PR TITLE
Improve PDF readability

### DIFF
--- a/src/components/DayGroup.js
+++ b/src/components/DayGroup.js
@@ -34,7 +34,7 @@ export default function DayGroup({
   ].filter(c => colorCounts[c]);
 
   return (
-    <div>
+    <div className="fd-day-group" style={styles.dayGroupContainer}>
       {collapsedDays.has(day) && !(isExportingPdf || isPrinting) ? (
         <div
           onClick={() => toggleDay(day)}
@@ -67,7 +67,11 @@ export default function DayGroup({
         </div>
       ) : (
         <React.Fragment>
-          <div onClick={() => toggleDay(day)} style={styles.groupHeader(isExportingPdf)}>
+          <div
+            onClick={() => toggleDay(day)}
+            className="fd-group-header"
+            style={styles.groupHeader(isExportingPdf)}
+          >
             <button
               onClick={e => { e.stopPropagation(); toggleDay(day); }}
               style={styles.collapseButton(dark)}

--- a/src/styles.js
+++ b/src/styles.js
@@ -106,7 +106,7 @@ const styles = {
     width: '100%',
     background: isPdf ? '#f5f5f5' : 'transparent',
     padding: isPdf ? '4px 8px' : 0,
-    borderBottom: '1px solid #ccc',
+    borderBottom: isPdf ? '1px solid #ccc' : 'none',
   }),
   dayCover: (dark, bandCount = 0, bandSpacing = 25, bandOffset = 0) => ({
     fontSize: 18,

--- a/src/styles.js
+++ b/src/styles.js
@@ -91,14 +91,22 @@ const styles = {
     pageBreakInside: 'avoid',
     breakInside: 'avoid'
   }),
+  dayGroupContainer: {
+    pageBreakInside: 'avoid',
+    breakInside: 'avoid',
+  },
   groupHeader: (isPdf) => ({
     fontSize: 18,
     fontWeight: 600,
-    margin: isPdf ? "32px 0 12px" : "24px 0 8px",
+    margin: isPdf ? "48px 0 12px" : "24px 0 8px",
     color: isPdf ? '#333' : undefined,
     display: 'flex',
     alignItems: 'center',
-    gap: '8px'
+    gap: '8px',
+    width: '100%',
+    background: isPdf ? '#f5f5f5' : 'transparent',
+    padding: isPdf ? '4px 8px' : 0,
+    borderBottom: '1px solid #ccc',
   }),
   dayCover: (dark, bandCount = 0, bandSpacing = 25, bandOffset = 0) => ({
     fontSize: 18,

--- a/src/utils/pdf.js
+++ b/src/utils/pdf.js
@@ -5,9 +5,30 @@ export async function exportTableToPdf(el) {
 
   const imgStackItemOriginalStyles = [];
   const individualImageOriginalStyles = [];
+  const headerOriginalBreaks = [];
   let prevBackground = '';
 
   try {
+    const headers = Array.from(el.querySelectorAll('.fd-group-header'));
+    headers.forEach(h => {
+      headerOriginalBreaks.push({
+        el: h,
+        breakBefore: h.style.breakBefore,
+        pageBreakBefore: h.style.pageBreakBefore,
+      });
+      h.style.breakBefore = '';
+      h.style.pageBreakBefore = '';
+    });
+
+    const marginPx = 10;
+    const pageHeightPx = 842 - marginPx * 2;
+    headers.forEach(h => {
+      const pos = (h.offsetTop - marginPx) % pageHeightPx;
+      if (pos > pageHeightPx * 0.9) {
+        h.style.pageBreakBefore = 'always';
+        h.style.breakBefore = 'page';
+      }
+    });
     const imgStackContainers = Array.from(el.querySelectorAll('.img-stack-container'));
     imgStackContainers.forEach(stackContainer => {
       const childrenItems = Array.from(stackContainer.children).filter(child => child.classList.contains('img-stack-item'));
@@ -50,6 +71,10 @@ export async function exportTableToPdf(el) {
       orig.el.style.width = orig.width;
       orig.el.style.height = orig.height;
       orig.el.style.objectFit = orig.objectFit;
+    });
+    headerOriginalBreaks.forEach(orig => {
+      orig.el.style.pageBreakBefore = orig.pageBreakBefore;
+      orig.el.style.breakBefore = orig.breakBefore;
     });
     if (prevBackground) el.style.backgroundColor = prevBackground;
   }


### PR DESCRIPTION
## Summary
- add page break styling for day groups
- draw a grey line behind group headers when exporting PDF
- increase spacing for PDF headlines and adjust background
- ensure new day headers start on a new page when close to bottom

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849aa3b02608332b66c8a3efb303f47