### PR TITLE
Improve symptom sorting and collapsed day indicators

### DIFF
--- a/src/styles.js
+++ b/src/styles.js
@@ -135,7 +135,7 @@ const styles = {
     height: `${size}px`,
     borderRadius: '50%',
     border: `2px solid ${color}`,
-    background: dark ? 'rgba(255, 255, 255, 0.1)' : 'rgba(0, 0, 0, 0.05)',
+    background: dark ? '#3c3c46' : '#fafafa',
     boxSizing: 'border-box',
     transform: 'translateY(-50%)',
     zIndex: 5,

--- a/src/utils.js
+++ b/src/utils.js
@@ -120,7 +120,12 @@ const sortSymptomsByTime = (symptoms) => {
     return [...symptoms].sort((a, b) => {
         const tA = typeof a.time === 'number' ? a.time : parseFloat(a.time) || 0;
         const tB = typeof b.time === 'number' ? b.time : parseFloat(b.time) || 0;
-        if (tA === tB) return (a.txt || '').localeCompare(b.txt || '');
+        if (tA === tB) {
+            const sA = typeof a.strength === 'number' ? a.strength : parseInt(a.strength) || 0;
+            const sB = typeof b.strength === 'number' ? b.strength : parseInt(b.strength) || 0;
+            if (sA !== sB) return sA - sB;
+            return (a.txt || '').localeCompare(b.txt || '');
+        }
         return tA - tB;
     });
 };


### PR DESCRIPTION
## Summary
- order symptoms by strength when times match
- fill collapsed day circles to match symptom styling

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a7e8fd5cc83329bfe75cf6627a1b9