### PR TITLE
Fix PDF day header spacing

### DIFF
--- a/src/components/DayGroup.js
+++ b/src/components/DayGroup.js
@@ -34,7 +34,7 @@ export default function DayGroup({
   ].filter(c => colorCounts[c]);
 
   return (
-    <div className="fd-day-group" style={styles.dayGroupContainer}>
+    <div className="fd-day-group" style={styles.dayGroupContainer(isExportingPdf)}>
       {collapsedDays.has(day) && !(isExportingPdf || isPrinting) ? (
         <div
           onClick={() => toggleDay(day)}

--- a/src/styles.js
+++ b/src/styles.js
@@ -91,14 +91,14 @@ const styles = {
     pageBreakInside: 'avoid',
     breakInside: 'avoid'
   }),
-  dayGroupContainer: {
-    pageBreakInside: 'avoid',
-    breakInside: 'avoid',
-  },
+  dayGroupContainer: (isPdf) => ({
+    pageBreakInside: isPdf ? 'auto' : 'avoid',
+    breakInside: isPdf ? 'auto' : 'avoid',
+  }),
   groupHeader: (isPdf) => ({
     fontSize: 18,
     fontWeight: 600,
-    margin: isPdf ? "48px 0 12px" : "24px 0 8px",
+    margin: isPdf ? "24px 0 8px" : "24px 0 8px",
     color: isPdf ? '#333' : undefined,
     display: 'flex',
     alignItems: 'center',


### PR DESCRIPTION
## Summary
- adjust `dayGroupContainer` to allow page breaks during PDF export
- use smaller margins on PDF day headers
- use new container style in `DayGroup`

## Testing
- `No tests run`

------
https://chatgpt.com/codex/tasks/task_e_684aa600438083329bd3ebeae0999ca7