### PR TITLE
Fix collapsed day symptom icon spacing

### DIFF
--- a/src/components/DayGroup.js
+++ b/src/components/DayGroup.js
@@ -48,7 +48,7 @@ export default function DayGroup({
           <div style={styles.dayCoverCounts}>
             {orderedColors.map(color => (
               <div key={color} style={styles.dayCoverCountPair(dark)}>
-                <span>{TAG_COLOR_ICONS[color]}</span>
+                <span style={{ width: 18, textAlign: 'center' }}>{TAG_COLOR_ICONS[color]}</span>
                 <span>{colorCounts[color]}</span>
               </div>
             ))}


### PR DESCRIPTION
## Summary
- adjust width around emoji icons in `DayGroup` so counts line up

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684abd2b9c348332a34f1053fff330ef