### PR TITLE
Add category selection row and symptom button state

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -869,6 +869,7 @@ export default function App() {
         FilterMenu={FilterMenu}
         TAG_COLORS={TAG_COLORS}
         TAG_COLOR_NAMES={TAG_COLOR_NAMES}
+        TAG_COLOR_ICONS={TAG_COLOR_ICONS}
         sortMode={sortMode}
         setSortMode={setSortMode}
       />

--- a/src/components/NewEntryForm.js
+++ b/src/components/NewEntryForm.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 
 export default function NewEntryForm({
   newForm,
@@ -42,6 +42,21 @@ export default function NewEntryForm({
   sortMode,
   setSortMode
 }) {
+  const categoryRowRef = useRef(null);
+
+  useEffect(() => {
+    const handler = e => {
+      if (categoryRowRef.current && !categoryRowRef.current.contains(e.target)) {
+        setNewForm(fm =>
+          fm.tagColorManual
+            ? { ...fm, tagColor: TAG_COLORS.GREEN, tagColorManual: false }
+            : fm
+        );
+      }
+    };
+    document.addEventListener('click', handler);
+    return () => document.removeEventListener('click', handler);
+  }, [setNewForm]);
   return (
     <div className="new-entry-form" style={{ marginBottom: 24 }}>
       <div id="food-input-container" style={{ position: 'relative', marginBottom: 8, display: 'flex', alignItems: 'center', gap: '6px' }}>
@@ -91,12 +106,21 @@ export default function NewEntryForm({
       </div>
       {newForm.imgs.length > 0 && <ImgStack imgs={newForm.imgs} onDelete={removeNewImg} />}
 
-      <div style={{ display: 'flex', gap: '8px', marginTop: newForm.imgs.length > 0 ? 8 : 0, marginBottom: 8 }}>
+      <div
+        ref={categoryRowRef}
+        style={{ display: 'flex', gap: '8px', marginTop: newForm.imgs.length > 0 ? 8 : 0, marginBottom: 8 }}
+      >
         {[TAG_COLORS.GREEN, TAG_COLORS.PURPLE, TAG_COLORS.RED, TAG_COLORS.BLUE, TAG_COLORS.BROWN, TAG_COLORS.YELLOW].map(colorValue => (
           <button
             key={colorValue}
             type="button"
-            onClick={() => setNewForm(fm => ({ ...fm, tagColor: colorValue, tagColorManual: true }))}
+            onClick={() =>
+              setNewForm(fm =>
+                fm.tagColorManual && fm.tagColor === colorValue
+                  ? { ...fm, tagColor: TAG_COLORS.GREEN, tagColorManual: false }
+                  : { ...fm, tagColor: colorValue, tagColorManual: true }
+              )
+            }
             style={styles.categoryButton(colorValue, newForm.tagColorManual && newForm.tagColor === colorValue, dark)}
             title={TAG_COLOR_NAMES[colorValue] || colorValue}
           >

--- a/src/components/NewEntryForm.js
+++ b/src/components/NewEntryForm.js
@@ -38,6 +38,7 @@ export default function NewEntryForm({
   FilterMenu,
   TAG_COLORS,
   TAG_COLOR_NAMES,
+  TAG_COLOR_ICONS,
   sortMode,
   setSortMode
 }) {
@@ -90,7 +91,21 @@ export default function NewEntryForm({
       </div>
       {newForm.imgs.length > 0 && <ImgStack imgs={newForm.imgs} onDelete={removeNewImg} />}
 
-      <div style={{ marginTop: newForm.imgs.length > 0 ? 8 : 0, marginBottom: 8 }}>
+      <div style={{ display: 'flex', gap: '8px', marginTop: newForm.imgs.length > 0 ? 8 : 0, marginBottom: 8 }}>
+        {[TAG_COLORS.GREEN, TAG_COLORS.PURPLE, TAG_COLORS.RED, TAG_COLORS.BLUE, TAG_COLORS.BROWN, TAG_COLORS.YELLOW].map(colorValue => (
+          <button
+            key={colorValue}
+            type="button"
+            onClick={() => setNewForm(fm => ({ ...fm, tagColor: colorValue, tagColorManual: true }))}
+            style={styles.colorPickerItem(colorValue, newForm.tagColorManual && newForm.tagColor === colorValue, dark)}
+            title={TAG_COLOR_NAMES[colorValue] || colorValue}
+          >
+            {TAG_COLOR_ICONS[colorValue]}
+          </button>
+        ))}
+      </div>
+
+      <div style={{ marginBottom: 8 }}>
       <div id="symptom-input-container" style={{ position: 'relative', marginBottom: '8px' }}>
         <input
           placeholder="Symptom..."
@@ -151,7 +166,14 @@ export default function NewEntryForm({
               </option>
             ))}
           </select>
-          <button onClick={addNewSymptom} style={styles.symptomAddButton('#388e3c')}>
+          <button
+            onClick={addNewSymptom}
+            disabled={!newForm.symptomInput.trim()}
+            style={{
+              ...styles.symptomAddButton('#388e3c'),
+              opacity: newForm.symptomInput.trim() ? 1 : 0.5,
+            }}
+          >
             +
           </button>
         </div>

--- a/src/components/NewEntryForm.js
+++ b/src/components/NewEntryForm.js
@@ -97,7 +97,7 @@ export default function NewEntryForm({
             key={colorValue}
             type="button"
             onClick={() => setNewForm(fm => ({ ...fm, tagColor: colorValue, tagColorManual: true }))}
-            style={styles.colorPickerItem(colorValue, newForm.tagColorManual && newForm.tagColor === colorValue, dark)}
+            style={styles.categoryButton(colorValue, newForm.tagColorManual && newForm.tagColor === colorValue, dark)}
             title={TAG_COLOR_NAMES[colorValue] || colorValue}
           >
             {TAG_COLOR_ICONS[colorValue]}

--- a/src/styles.js
+++ b/src/styles.js
@@ -240,6 +240,25 @@ const styles = {
     border: isActive ? (currentThemeDark ? '2px solid #FFFFFF' : '2px solid #000000') : '2px solid transparent',
     boxSizing: 'border-box',
   }),
+  categoryButton: (color, isActive, dark) => ({
+    width: '40px',
+    height: '40px',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    fontSize: '24px',
+    borderRadius: '8px',
+    cursor: 'pointer',
+    background: dark ? 'rgba(255,255,255,0.08)' : 'rgba(0,0,0,0.04)',
+    backdropFilter: 'blur(4px)',
+    border: isActive
+      ? `2px solid ${dark ? '#ffffff' : '#000000'}`
+      : dark
+      ? '1px solid rgba(255,255,255,0.15)'
+      : '1px solid rgba(0,0,0,0.1)',
+    boxSizing: 'border-box',
+    color: dark ? '#f0f0f8' : '#333',
+  }),
   categoryIcon: {
     position: 'absolute',
     top: '50%',


### PR DESCRIPTION
## Summary
- extend new entry form state with tag color handling
- allow manual category choice via new row of tag icons
- grey out symptom add button when input is empty
- pass icon constants to the entry form

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ac480659483329cf096b593db35f0