### PR TITLE
Update category deselect logic

### DIFF
--- a/src/components/NewEntryForm.js
+++ b/src/components/NewEntryForm.js
@@ -46,7 +46,12 @@ export default function NewEntryForm({
 
   useEffect(() => {
     const handler = e => {
-      if (categoryRowRef.current && !categoryRowRef.current.contains(e.target)) {
+      const target = e.target;
+      const clickedInsideCategory = categoryRowRef.current && categoryRowRef.current.contains(target);
+      const isTextInput = target.tagName === 'INPUT' || target.tagName === 'TEXTAREA';
+      const submitBtnClicked = target.closest('#add-entry-button');
+
+      if (!clickedInsideCategory && !isTextInput && !submitBtnClicked) {
         setNewForm(fm =>
           fm.tagColorManual
             ? { ...fm, tagColor: TAG_COLORS.GREEN, tagColorManual: false }
@@ -208,6 +213,7 @@ export default function NewEntryForm({
         ))}
       </div>
       <button
+        id="add-entry-button"
         onClick={addEntry}
         disabled={!newForm.food.trim() && newSymptoms.length === 0}
         style={{ ...styles.buttonPrimary, opacity: newForm.food.trim() || newSymptoms.length > 0 ? 1 : 0.5 }}


### PR DESCRIPTION
## Summary
- prevent category reset when clicking input fields or the entry submit button
- add `id` to entry submission button

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684ac926e938833297a404fd11f40aef