### PR TITLE
Add portion selection for new entries

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -43,6 +43,8 @@ export default function App() {
               ? e.linkId
               : (e.linkId ? parseInt(e.linkId, 10) || null : null),
             createdAt: e.createdAt || (parseDateString(e.date).getTime() + i / 1000),
+            portionSize: e.portionSize || null,
+            portionGrams: e.portionGrams || '',
           };
           if (!base.tagColorManual) {
             base.tagColor = determineTagColor(base.food, base.symptoms);

--- a/src/components/EntryCard.js
+++ b/src/components/EntryCard.js
@@ -445,21 +445,39 @@ export default function EntryCard({
 
           <>
             <div
-              id={`tag-marker-${idx}`}
-              style={styles.categoryIcon}
-              onClick={e => {
-                if (isExportingPdf) return;
-                e.stopPropagation();
-                setColorPickerOpenForIdx(colorPickerOpenForIdx === idx ? null : idx);
-                setNoteOpenIdx(null);
+              style={{
+                position: 'absolute',
+                top: '50%',
+                right: '6px',
+                transform: 'translateY(-50%)',
+                display: 'flex',
+                alignItems: 'center',
+                gap: '4px',
+                zIndex: 6,
               }}
-              title={
-                !isExportingPdf
-                  ? `Markierung: ${TAG_COLOR_NAMES[currentTagColor] || 'Unbekannt'}. Klicken zum Ändern.`
-                  : `Markierung: ${TAG_COLOR_NAMES[currentTagColor] || 'Unbekannt'}`
-              }
             >
-              {TAG_COLOR_ICONS[currentTagColor]}
+              {entry.portionSize && (
+                <span style={{ fontSize: 12 }}>
+                  {entry.portionSize === 'custom' ? `${entry.portionGrams}g` : entry.portionSize}
+                </span>
+              )}
+              <div
+                id={`tag-marker-${idx}`}
+                style={styles.categoryIcon}
+                onClick={e => {
+                  if (isExportingPdf) return;
+                  e.stopPropagation();
+                  setColorPickerOpenForIdx(colorPickerOpenForIdx === idx ? null : idx);
+                  setNoteOpenIdx(null);
+                }}
+                title={
+                  !isExportingPdf
+                    ? `Markierung: ${TAG_COLOR_NAMES[currentTagColor] || 'Unbekannt'}. Klicken zum Ändern.`
+                    : `Markierung: ${TAG_COLOR_NAMES[currentTagColor] || 'Unbekannt'}`
+                }
+              >
+                {TAG_COLOR_ICONS[currentTagColor]}
+              </div>
             </div>
 
             {!isExportingPdf && colorPickerOpenForIdx === idx && (

--- a/src/components/NewEntryForm.js
+++ b/src/components/NewEntryForm.js
@@ -51,6 +51,9 @@ export default function NewEntryForm({
   const filterBtnRef = useRef(null);
   const filterMenuRef = useRef(null);
   const [showCategories, setShowCategories] = useState(false);
+  const [portionMenuOpen, setPortionMenuOpen] = useState(false);
+  const [portionSize, setPortionSize] = useState('middle');
+  const [portionGrams, setPortionGrams] = useState('');
 
   useEffect(() => {
     const handler = e => {
@@ -284,7 +287,7 @@ export default function NewEntryForm({
         ))}
       </div>
       <button
-        onClick={addEntry}
+        onClick={() => setPortionMenuOpen(true)}
         disabled={!newForm.food.trim() && newSymptoms.length === 0}
         style={{ ...styles.buttonPrimary, opacity: newForm.food.trim() || newSymptoms.length > 0 ? 1 : 0.5 }}
       >
@@ -326,6 +329,56 @@ export default function NewEntryForm({
           )}
         </div>
       </div>
+      {portionMenuOpen && (
+        <div
+          style={{
+            position: 'fixed',
+            top: 0,
+            left: 0,
+            right: 0,
+            bottom: 0,
+            background: 'rgba(0,0,0,0.4)',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            zIndex: 1000,
+          }}
+          onClick={() => setPortionMenuOpen(false)}
+        >
+          <div
+            style={{ background: dark ? '#333' : '#fff', padding: 24, borderRadius: 8, minWidth: 200 }}
+            onClick={e => e.stopPropagation()}
+          >
+            <div style={{ marginBottom: 8 }}>Portionsgröße wählen</div>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+              {['small','middle','big'].map(size => (
+                <button
+                  key={size}
+                  onClick={() => { setPortionSize(size); setPortionMenuOpen(false); addEntry(size, ''); setPortionSize('middle'); setPortionGrams(''); }}
+                  style={styles.buttonSecondary('#1976d2')}
+                >
+                  {size}
+                </button>
+              ))}
+              <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
+                <input
+                  value={portionGrams}
+                  onChange={e => { setPortionSize('custom'); setPortionGrams(e.target.value); }}
+                  placeholder="Gramm"
+                  style={{ ...styles.smallInput, flexGrow: 1 }}
+                />
+                <button
+                  onClick={() => { if (portionGrams.trim()) { setPortionMenuOpen(false); addEntry('custom', portionGrams.trim()); setPortionSize('middle'); setPortionGrams(''); } }}
+                  style={styles.buttonSecondary('#388e3c')}
+                >
+                  OK
+                </button>
+              </div>
+            </div>
+            <button onClick={() => setPortionMenuOpen(false)} style={{ ...styles.buttonSecondary('#888'), marginTop: 8 }}>Abbrechen</button>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/hooks/useNewEntryForm.js
+++ b/src/hooks/useNewEntryForm.js
@@ -65,7 +65,7 @@ export default function useNewEntryForm(setEntries, addToast) {
 
   const removeNewSymptom = idx => setNewSymptoms(s => s.filter((_, i) => i !== idx));
 
-  const addEntry = () => {
+  const addEntry = (portionSize = null, portionGrams = '') => {
     const pendingSymptom = newForm.symptomInput.trim()
       ? { txt: newForm.symptomInput.trim(), time: newForm.symptomTime, strength: newForm.symptomStrength }
       : null;
@@ -85,6 +85,8 @@ export default function useNewEntryForm(setEntries, addToast) {
       tagColorManual: newForm.tagColorManual,
       linkId: null,
       createdAt: Date.now(),
+      portionSize: portionSize,
+      portionGrams: portionGrams,
     };
     setEntries(prev => [...prev, entry].sort(sortEntries));
     setNewForm({ food: '', imgs: [], symptomInput: '', symptomTime: 0, symptomStrength: 1, tagColor: TAG_COLORS.GREEN, tagColorManual: false });


### PR DESCRIPTION
## Summary
- allow specifying portion information when creating entries
- show portion sizes in entry cards

## Testing
- `npm install`
- `CI=true npm test --silent` *(fails: No tests found)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684c1f5f2d408332a440b0b466f28e77