### PR TITLE
Align entry icons and adjust date display

### DIFF
--- a/src/components/DayGroup.js
+++ b/src/components/DayGroup.js
@@ -42,7 +42,7 @@ export default function DayGroup({
             >
               ▶
             </button>
-            {day}
+            {day.split('.').slice(0, 2).join('.')}
           </div>
           <div style={styles.dayCoverCounts}>
             {orderedColors.map(color => (

--- a/src/components/EntryCard.js
+++ b/src/components/EntryCard.js
@@ -360,34 +360,53 @@ export default function EntryCard({
       ) : (
         <>
 
-          <div
-            style={{
-              fontSize: 12,
-              opacity: 0.7,
-              marginBottom: 4,
-              marginRight: '65px',
-              color: isExportingPdf
-                ? dark
-                  ? '#ffffff'
-                  : '#444444'
-                : dark
-                ? '#cccccc'
-                : '#444444'
-            }}
-          >
-            {(entry.date && entry.date.split(' ')[1]) || entry.date}
-          </div>
-          <div
-            style={{
-              fontSize: 18,
-              fontWeight: 600,
-              marginBottom: 8,
-              marginRight: '65px',
-              overflowWrap: 'break-word',
-              whiteSpace: 'normal'
-            }}
-          >
-            {entry.food || (isSymptomOnlyEntry ? 'Nur Symptome' : '(Kein Essen)')}
+          <div style={styles.entryHeaderRow}>
+            <div style={{ flexGrow: 1 }}>
+              <div
+                style={{
+                  fontSize: 12,
+                  opacity: 0.7,
+                  marginBottom: 4,
+                  color: isExportingPdf
+                    ? dark
+                      ? '#ffffff'
+                      : '#444444'
+                    : dark
+                    ? '#cccccc'
+                    : '#444444'
+                }}
+              >
+                {(entry.date && entry.date.split(' ')[1]) || entry.date}
+              </div>
+              <div
+                style={{
+                  fontSize: 18,
+                  fontWeight: 600,
+                  marginBottom: 8,
+                  overflowWrap: 'break-word',
+                  whiteSpace: 'normal'
+                }}
+              >
+                {entry.food || (isSymptomOnlyEntry ? 'Nur Symptome' : '(Kein Essen)')}
+              </div>
+            </div>
+            <div
+              id={`tag-marker-${idx}`}
+              style={styles.categoryIcon}
+              onClick={e => {
+                if (isExportingPdf) return;
+                e.stopPropagation();
+                setColorPickerOpenForIdx(colorPickerOpenForIdx === idx ? null : idx);
+                setNoteOpenIdx(null);
+              }}
+              title={
+                !isExportingPdf
+                  ? `Markierung: ${TAG_COLOR_NAMES[currentTagColor] || 'Unbekannt'}. Klicken zum Ändern.`
+                  : `Markierung: ${TAG_COLOR_NAMES[currentTagColor] || 'Unbekannt'}`
+              }
+            >
+              {TAG_COLOR_ICONS[currentTagColor]}
+            </div>
           </div>
 
           {entry.imgs.length > 0 && <ImgStack imgs={entry.imgs} />}
@@ -443,26 +462,7 @@ export default function EntryCard({
             </div>
           )}
 
-          <>
-            <div
-              id={`tag-marker-${idx}`}
-              style={styles.categoryIcon}
-              onClick={e => {
-                if (isExportingPdf) return;
-                e.stopPropagation();
-                setColorPickerOpenForIdx(colorPickerOpenForIdx === idx ? null : idx);
-                setNoteOpenIdx(null);
-              }}
-              title={
-                !isExportingPdf
-                  ? `Markierung: ${TAG_COLOR_NAMES[currentTagColor] || 'Unbekannt'}. Klicken zum Ändern.`
-                  : `Markierung: ${TAG_COLOR_NAMES[currentTagColor] || 'Unbekannt'}`
-              }
-            >
-              {TAG_COLOR_ICONS[currentTagColor]}
-            </div>
-
-            {!isExportingPdf && colorPickerOpenForIdx === idx && (
+          {!isExportingPdf && colorPickerOpenForIdx === idx && (
               <div
                 id={`color-picker-popup-${idx}`}
                 style={styles.colorPickerPopup(dark)}
@@ -480,7 +480,6 @@ export default function EntryCard({
                 ))}
               </div>
             )}
-          </>
         </>
       )}
     </div>

--- a/src/styles.js
+++ b/src/styles.js
@@ -91,6 +91,10 @@ const styles = {
     pageBreakInside: 'avoid',
     breakInside: 'avoid'
   }),
+  entryHeaderRow: {
+    display: 'flex',
+    alignItems: 'center',
+  },
   dayGroupContainer: (isPdf) => ({
     pageBreakInside: isPdf ? 'auto' : 'avoid',
     breakInside: isPdf ? 'auto' : 'avoid',
@@ -277,13 +281,12 @@ const styles = {
     color: dark ? '#f0f0f8' : '#333',
   }),
   categoryIcon: {
-    position: 'absolute',
-    top: '50%',
-    right: '6px',
-    transform: 'translateY(-50%)',
     fontSize: '20px',
-    zIndex: 6,
+    marginLeft: '8px',
     cursor: 'pointer',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
   },
   pinContainer: {
     position: 'absolute',


### PR DESCRIPTION
## Summary
- show collapsed day names without the year
- align entry category symbol with the text by adding `entryHeaderRow` style
- remove absolute positioning from `categoryIcon`

## Testing
- `npm test --silent` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_684ec77eac748332b4ec6fdfadbdd7c5