### PR TITLE
Fix collapsed day display and icon positioning

### DIFF
--- a/src/components/DayGroup.js
+++ b/src/components/DayGroup.js
@@ -42,7 +42,8 @@ export default function DayGroup({
             >
               ▶
             </button>
-            {day}
+            {/* display day without year when collapsed */}
+            {day.split('.').slice(0, 2).join('.')}
           </div>
           <div style={styles.dayCoverCounts}>
             {orderedColors.map(color => (

--- a/src/styles.js
+++ b/src/styles.js
@@ -278,7 +278,8 @@ const styles = {
   }),
   categoryIcon: {
     position: 'absolute',
-    top: '50%',
+    // Align icon with main text line instead of overall card height
+    top: '36px',
     right: '6px',
     transform: 'translateY(-50%)',
     fontSize: '20px',


### PR DESCRIPTION
## Summary
- show day and month only when a day group is collapsed
- align the entry category icon with the main text line

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684ec77eac748332b4ec6fdfadbdd7c5