### PR TITLE
Add export dropdown and language switcher

### DIFF
--- a/src/LanguageContext.js
+++ b/src/LanguageContext.js
@@ -1,0 +1,4 @@
+import React, { createContext, useContext } from 'react';
+
+export const LanguageContext = createContext('de');
+export const useLanguage = () => useContext(LanguageContext);

--- a/src/components/DayGroup.js
+++ b/src/components/DayGroup.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import EntryCard from './EntryCard';
+import { formatCollapsedDay } from '../utils';
 
 export default function DayGroup({
   day,
@@ -15,6 +16,7 @@ export default function DayGroup({
   styles,
   TAG_COLORS,
   TAG_COLOR_ICONS,
+  language,
 }) {
   const colorCounts = entries.reduce((acc, { entry }) => {
     const color = entry.tagColor || TAG_COLORS.GREEN;
@@ -43,7 +45,7 @@ export default function DayGroup({
               ▶
             </button>
             {/* display day without year when collapsed */}
-            {day.split('.').slice(0, 2).join('.')}
+            {formatCollapsedDay(day, language)}
           </div>
           <div style={styles.dayCoverCounts}>
             {orderedColors.map(color => (

--- a/src/components/ExportButton.js
+++ b/src/components/ExportButton.js
@@ -1,0 +1,66 @@
+import React, { useState, useRef, useEffect } from 'react';
+import styles from '../styles';
+import useTranslation from '../useTranslation';
+
+const ExportButton = ({ onExportPdf, onPrint, dark }) => {
+  const [open, setOpen] = useState(false);
+  const ref = useRef(null);
+  const t = useTranslation();
+
+  useEffect(() => {
+    const handler = e => {
+      if (ref.current && !ref.current.contains(e.target)) {
+        setOpen(false);
+      }
+    };
+    if (open) document.addEventListener('mousedown', handler);
+    return () => document.removeEventListener('mousedown', handler);
+  }, [open]);
+
+  return (
+    <div ref={ref} style={{ position: 'relative' }}>
+      <button
+        onClick={() => setOpen(o => !o)}
+        className="haptic"
+        title={t('Export')}
+        style={styles.glassyButtonAccent(dark)}
+      >
+        {t('Export')}
+      </button>
+      {open && (
+        <div
+          style={{
+            position: 'absolute',
+            top: '100%',
+            right: 0,
+            background: dark ? '#333' : '#fff',
+            border: '1px solid #ccc',
+            borderRadius: 4,
+            padding: 4,
+            zIndex: 1000,
+            display: 'flex',
+            flexDirection: 'column',
+            minWidth: 80,
+          }}
+        >
+          <button
+            className="haptic"
+            onClick={() => { setOpen(false); onExportPdf(); }}
+            style={{ ...styles.buttonSecondary('transparent'), textAlign: 'left' }}
+          >
+            {t('PDF')}
+          </button>
+          <button
+            className="haptic"
+            onClick={() => { setOpen(false); onPrint(); }}
+            style={{ ...styles.buttonSecondary('transparent'), textAlign: 'left' }}
+          >
+            {t('Print')}
+          </button>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default ExportButton;

--- a/src/components/LanguageButton.js
+++ b/src/components/LanguageButton.js
@@ -1,0 +1,21 @@
+import React from 'react';
+import styles from '../styles';
+import { useLanguage } from '../LanguageContext';
+
+const FLAG = { en: '🇺🇸', de: '🇩🇪' };
+
+const LanguageButton = ({ toggle, dark }) => {
+  const lang = useLanguage();
+  return (
+    <button
+      onClick={toggle}
+      className="haptic"
+      title="Language"
+      style={styles.glassyButtonAccent(dark)}
+    >
+      {FLAG[lang] || lang}
+    </button>
+  );
+};
+
+export default LanguageButton;

--- a/src/translations.js
+++ b/src/translations.js
@@ -1,0 +1,23 @@
+const translations = {
+  en: {
+    'Export': 'Export',
+    'Print': 'Print',
+    'PDF': 'PDF',
+    'PDF erfolgreich exportiert!': 'PDF exported successfully!',
+    'Fehler beim PDF-Export.': 'Error during PDF export.',
+    'PDF Export wird vorbereitet...': 'Preparing PDF export...',
+    'Food Diary': 'Food Diary',
+    'Pers\u00f6nliche Daten': 'Personal Data',
+    'Schlie\u00dfen': 'Close',
+    'Alter': 'Age',
+    'Geschlecht': 'Gender',
+    'Gr\u00f6\u00dfe (cm)': 'Height (cm)',
+    'Gewicht (kg)': 'Weight (kg)',
+    'Link-ID w\u00e4hlen': 'Select Link ID',
+    'Neu': 'New',
+    'Abbrechen': 'Cancel',
+  },
+  de: {}
+};
+
+export default translations;

--- a/src/useTranslation.js
+++ b/src/useTranslation.js
@@ -1,0 +1,8 @@
+import { useContext } from 'react';
+import { LanguageContext } from './LanguageContext';
+import translations from './translations';
+
+export default function useTranslation() {
+  const lang = useContext(LanguageContext);
+  return (text) => translations[lang] && translations[lang][text] ? translations[lang][text] : text;
+}

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,5 +1,23 @@
 // --- HILFSFUNKTIONEN ---
 import { TAG_COLORS } from "./constants";
+const MONTH_NAMES = {
+  en: ["January","February","March","April","May","June","July","August","September","October","November","December"],
+  de: ["Januar","Februar","Mrz","April","Mai","Juni","Juli","August","September","Oktober","November","Dezember"]
+};
+function englishOrdinal(n){
+  if(n%10===1&&n%100!==11) return "st";
+  if(n%10===2&&n%100!==12) return "nd";
+  if(n%10===3&&n%100!==13) return "rd";
+  return "th";
+}
+function formatCollapsedDay(day, lang){
+  const [d,m] = day.split(".");
+  const dayNum = parseInt(d,10);
+  const monthIdx = parseInt(m,10)-1;
+  if(lang==="de") return `${dayNum}. ${MONTH_NAMES.de[monthIdx]}`;
+  return `${dayNum}${englishOrdinal(dayNum)} of ${MONTH_NAMES.en[monthIdx]}`;
+}
+
 function resizeToJpeg(file, maxWidth = 800) {
   return new Promise((resolve, reject) => {
     const reader = new FileReader();
@@ -159,4 +177,4 @@ const sortEntriesByCategory = (a, b) => {
 };
 
 
-export { resizeToJpeg, getStrengthColor, now, vibrate, getTodayDateString, parseDateString, toDateTimePickerFormat, fromDateTimePickerFormat, sortSymptomsByTime, determineTagColor, sortEntries, sortEntriesByCategory };
+export { resizeToJpeg, getStrengthColor, now, vibrate, getTodayDateString, parseDateString, toDateTimePickerFormat, fromDateTimePickerFormat, sortSymptomsByTime, determineTagColor, sortEntries, sortEntriesByCategory , formatCollapsedDay };


### PR DESCRIPTION
## Summary
- replace separate PDF/print buttons with unified `Export` dropdown
- add language toggle button with flag icon
- store language preference and wrap app in `LanguageContext`
- show collapsed day dates formatted per language
- include basic translations for new text

## Testing
- `npm test --silent`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684ef2c19cb0833291fb4c3dd9573565