### PR TITLE
Fix portion menu positioning and open behavior

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -99,7 +99,7 @@ export default function App() {
   });
   const [showEditFoodQuick, setShowEditFoodQuick] = useState(false);
   const [showEditSymptomQuick, setShowEditSymptomQuick] = useState(false);
-  const [showEditPortionQuick, setShowEditPortionQuick] = useState(false);
+  const [showEditPortionQuickIdx, setShowEditPortionQuickIdx] = useState(null);
   const [filterTags, setFilterTags] = useState([]);
   const [filterMenuOpen, setFilterMenuOpen] = useState(false);
   const [sortMode, setSortMode] = useState('date');
@@ -245,9 +245,9 @@ export default function App() {
         const area = document.getElementById('edit-symptom-input-container');
         if (area && !area.contains(e.target)) setShowEditSymptomQuick(false);
       }
-      if (showEditPortionQuick) {
+      if (showEditPortionQuickIdx !== null) {
         const area = document.getElementById('portion-picker-container');
-        if (area && !area.contains(e.target)) setShowEditPortionQuick(false);
+        if (area && !area.contains(e.target)) setShowEditPortionQuickIdx(null);
       }
       if (filterMenuOpen) {
         const area = document.getElementById('filter-menu-container');
@@ -256,7 +256,7 @@ export default function App() {
     };
     document.addEventListener('mousedown', handleQuickClose);
     return () => document.removeEventListener('mousedown', handleQuickClose);
-  }, [showEditFoodQuick, showEditSymptomQuick, showEditPortionQuick, filterMenuOpen]);
+  }, [showEditFoodQuick, showEditSymptomQuick, showEditPortionQuickIdx, filterMenuOpen]);
 
   const knownDaysRef = useRef(new Set());
 
@@ -476,7 +476,7 @@ export default function App() {
     setEditForm(null);
     setShowEditFoodQuick(false);
     setShowEditSymptomQuick(false);
-    setShowEditPortionQuick(false);
+    setShowEditPortionQuickIdx(null);
   };
 
   const addEditSymptom = () => {
@@ -620,7 +620,7 @@ export default function App() {
       )
     );
     addToast(t('Portion geändert'));
-    setShowEditPortionQuick(false);
+    setShowEditPortionQuickIdx(null);
   };
 
   const handlePinClick = (idx) => {
@@ -1001,8 +1001,8 @@ export default function App() {
               setShowEditFoodQuick,
               showEditSymptomQuick,
               setShowEditSymptomQuick,
-              showEditPortionQuick,
-              setShowEditPortionQuick,
+              showEditPortionQuickIdx,
+              setShowEditPortionQuickIdx,
             }}
             styles={styles}
             TAG_COLORS={TAG_COLORS}

--- a/src/components/EntryCard.js
+++ b/src/components/EntryCard.js
@@ -54,8 +54,8 @@ export default function EntryCard({
   setShowEditFoodQuick,
   showEditSymptomQuick,
   setShowEditSymptomQuick,
-  showEditPortionQuick,
-  setShowEditPortionQuick,
+  showEditPortionQuickIdx,
+  setShowEditPortionQuickIdx,
   marginBottom = 16
 }) {
   const t = useTranslation();
@@ -115,7 +115,7 @@ export default function EntryCard({
           </svg>
         </div>
       </div>
-      {editingIdx !== idx && (
+      {editingIdx !== idx && [TAG_COLORS.GREEN, TAG_COLORS.RED].includes(entry.tagColor || TAG_COLORS.GREEN) && (
         <div
           id={`portion-label-${idx}`}
           style={styles.portionLabel(
@@ -127,7 +127,7 @@ export default function EntryCard({
             setQuickGrams(
               entry.portion?.size === 'custom' ? entry.portion.grams || '' : ''
             );
-            setShowEditPortionQuick(s => !s);
+            setShowEditPortionQuickIdx(prev => prev === idx ? null : idx);
           }}
           title={t('Portion wählen')}
         >
@@ -516,7 +516,7 @@ export default function EntryCard({
               </div>
             )}
 
-            {!isExportingPdf && showEditPortionQuick && (
+            {!isExportingPdf && showEditPortionQuickIdx === idx && (
               <div
                 id="portion-picker-container"
                 style={styles.portionPickerPopup(dark)}
@@ -560,7 +560,7 @@ export default function EntryCard({
                       if (editingIdx !== idx) {
                         handlePortionChange(idx, { size: 'custom', grams: quickGrams });
                       }
-                      setShowEditPortionQuick(false);
+                      setShowEditPortionQuickIdx(null);
                     }}
                     style={{ ...styles.buttonSecondary('#1976d2'), padding: '4px 8px', fontSize: 12 }}
                   >

--- a/src/styles.js
+++ b/src/styles.js
@@ -332,7 +332,7 @@ const styles = {
   portionPickerPopup: (dark) => ({
     position: 'absolute',
     top: '50%',
-    left: 'calc(100% + 4px)',
+    right: 'calc(100% + 4px)',
     transform: 'translateY(-50%)',
     background: dark ? '#4a4a52' : '#fff',
     padding: '8px',


### PR DESCRIPTION
## Summary
- open portion picker leftwards
- track portion picker state per entry
- only show portion picker for food and symptom entries

## Testing
- `npm test --silent -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_684f0e17d0088332b0e0e0aee86a7c32