### PR TITLE
Update portion handling

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -43,7 +43,7 @@ export default function App() {
             symptoms,
             tagColor: e.tagColor || TAG_COLORS.GREEN,
             tagColorManual: e.tagColorManual || false,
-            portion: e.portion || { size: 'M', grams: null },
+            portion: e.portion || { size: null, grams: null },
             linkId: typeof e.linkId === 'number'
               ? e.linkId
               : (e.linkId ? parseInt(e.linkId, 10) || null : null),
@@ -464,7 +464,7 @@ export default function App() {
         newSymptomStrength: 1,
         date: toDateTimePickerFormat(e.date),
         linkId: e.linkId || null,
-        portion: e.portion || { size: 'M', grams: null }
+        portion: e.portion || { size: null, grams: null }
     });
     setColorPickerOpenForIdx(null);
     setNoteOpenIdx(null);

--- a/src/components/EntryCard.js
+++ b/src/components/EntryCard.js
@@ -80,8 +80,10 @@ export default function EntryCard({
     : (dark ? styles.entryCard(dark, false).background : styles.entryCard(false, false).background);
 
   const currentTagColor = entry.tagColor || TAG_COLORS.GREEN;
-  const currentPortion = editingIdx === idx && editForm ? (editForm.portion || { size: 'M', grams: null }) : (entry.portion || { size: 'M', grams: null });
-  const portionDisplay = currentPortion.size === 'custom' ? `${currentPortion.grams || ''}g` : currentPortion.size;
+  const currentPortion = editingIdx === idx && editForm ? (editForm.portion || { size: null, grams: null }) : (entry.portion || { size: null, grams: null });
+  const portionDisplay = currentPortion.size === 'custom'
+    ? `${currentPortion.grams || ''}g`
+    : currentPortion.size;
 
   return (
     <div
@@ -132,7 +134,7 @@ export default function EntryCard({
             }}
             title={t('Portion wählen')}
           >
-            {portionDisplay || 'M'}
+            {portionDisplay || t('Portion')}
           </div>
           {!isExportingPdf && showEditPortionQuickIdx === idx && (
             <div
@@ -145,7 +147,7 @@ export default function EntryCard({
                   key={size}
                   style={styles.portionPickerItem(
                     PORTION_COLORS[size],
-                    (editingIdx === idx ? editForm.portion : entry.portion || { size: 'M' }).size === size,
+                    (editingIdx === idx ? editForm.portion : entry.portion || { size: null }).size === size,
                     dark
                   )}
                   onClick={() => {
@@ -183,6 +185,20 @@ export default function EntryCard({
                   style={{ ...styles.buttonSecondary('#1976d2'), padding: '4px 8px', fontSize: 12 }}
                 >
                   OK
+                </button>
+                <button
+                  onClick={() => {
+                    if (editingIdx === idx) {
+                      setEditForm(fm => ({ ...fm, portion: null }));
+                    } else {
+                      handlePortionChange(idx, null);
+                    }
+                    setShowEditPortionQuickIdx(null);
+                  }}
+                  style={{ ...styles.buttonSecondary('#d32f2f'), padding: '4px 8px', fontSize: 12 }}
+                  title={t('Portion entfernen')}
+                >
+                  ×
                 </button>
               </div>
             </div>

--- a/src/components/EntryCard.js
+++ b/src/components/EntryCard.js
@@ -229,8 +229,10 @@ export default function EntryCard({
             onChange={e => setEditForm(fm => ({ ...fm, date: e.target.value }))}
             style={{
               ...styles.input,
+              display: 'inline-block',
               marginBottom: '12px',
-              width: showPortion ? 'calc(100% - 70px)' : '100%'
+              width: 'fit-content',
+              marginRight: showPortion ? '70px' : 0
             }}
           />
           <div style={{ display: 'flex', alignItems: 'center', gap: '4px', marginBottom: '8px' }}>

--- a/src/components/EntryCard.js
+++ b/src/components/EntryCard.js
@@ -227,7 +227,11 @@ export default function EntryCard({
             type="datetime-local"
             value={editForm.date}
             onChange={e => setEditForm(fm => ({ ...fm, date: e.target.value }))}
-            style={{ ...styles.input, marginBottom: '12px', width: '100%' }}
+            style={{
+              ...styles.input,
+              marginBottom: '12px',
+              width: showPortion ? 'calc(100% - 70px)' : '100%'
+            }}
           />
           <div style={{ display: 'flex', alignItems: 'center', gap: '4px', marginBottom: '8px' }}>
             <div id="edit-food-input-container" style={{ position: 'relative', flexGrow: 1 }}>

--- a/src/components/EntryCard.js
+++ b/src/components/EntryCard.js
@@ -80,10 +80,17 @@ export default function EntryCard({
     : (dark ? styles.entryCard(dark, false).background : styles.entryCard(false, false).background);
 
   const currentTagColor = entry.tagColor || TAG_COLORS.GREEN;
-  const currentPortion = editingIdx === idx && editForm ? (editForm.portion || { size: null, grams: null }) : (entry.portion || { size: null, grams: null });
-  const portionDisplay = currentPortion.size === 'custom'
-    ? `${currentPortion.grams || ''}g`
-    : currentPortion.size;
+  const currentPortion =
+    editingIdx === idx && editForm
+      ? editForm.portion || { size: null, grams: null }
+      : entry.portion || { size: null, grams: null };
+  const portionDisplay =
+    currentPortion.size === 'custom'
+      ? `${currentPortion.grams || ''}g`
+      : currentPortion.size;
+  const showPortion =
+    [TAG_COLORS.GREEN, TAG_COLORS.RED].includes(entry.tagColor || TAG_COLORS.GREEN) &&
+    (editingIdx === idx || (entry.portion && entry.portion.size));
 
   return (
     <div
@@ -117,7 +124,7 @@ export default function EntryCard({
           </svg>
         </div>
       </div>
-      {editingIdx !== idx && [TAG_COLORS.GREEN, TAG_COLORS.RED].includes(entry.tagColor || TAG_COLORS.GREEN) && (
+      {showPortion && (
         <div style={styles.portionContainer()}>
           <div
             id={`portion-label-${idx}`}

--- a/src/components/NewEntryForm.js
+++ b/src/components/NewEntryForm.js
@@ -202,10 +202,12 @@ export default function NewEntryForm({
               ...styles.glassyButton(dark),
               color: PORTION_COLORS[
                 newForm.portion.size === 'custom' ? 'M' : newForm.portion.size
-              ],
+              ] || '#aaa',
             }}
           >
-            {newForm.portion.size === 'custom' ? `${newForm.portion.grams || ''}g` : newForm.portion.size}
+            {newForm.portion.size === 'custom'
+              ? `${newForm.portion.grams || ''}g`
+              : newForm.portion.size || t('Portion')}
           </button>
           {showPortionQuick && (
             <div ref={portionMenuRef} style={styles.portionPickerPopup(dark)}>
@@ -227,6 +229,13 @@ export default function NewEntryForm({
                 />
                 <span>g</span>
                 <button onClick={() => setShowPortionQuick(false)} style={{ ...styles.buttonSecondary('#1976d2'), padding: '4px 8px', fontSize: 12 }}>OK</button>
+                <button
+                  onClick={() => { setNewForm(fm => ({ ...fm, portion: { size: null, grams: null } })); setShowPortionQuick(false); }}
+                  style={{ ...styles.buttonSecondary('#d32f2f'), padding: '4px 8px', fontSize: 12 }}
+                  title={t('Portion entfernen')}
+                >
+                  ×
+                </button>
               </div>
             </div>
           )}

--- a/src/hooks/useNewEntryForm.js
+++ b/src/hooks/useNewEntryForm.js
@@ -7,7 +7,7 @@ export default function useNewEntryForm(setEntries, addToast) {
   const t = useTranslation();
   const [newForm, setNewForm] = useState(() => {
     const saved = localStorage.getItem('fd-form-new');
-    const initialForm = { food: '', imgs: [], symptomInput: '', symptomTime: 0, symptomStrength: 1, tagColor: TAG_COLORS.GREEN, tagColorManual: false, portion: { size: 'M', grams: null } };
+    const initialForm = { food: '', imgs: [], symptomInput: '', symptomTime: 0, symptomStrength: 1, tagColor: TAG_COLORS.GREEN, tagColorManual: false, portion: { size: null, grams: null } };
     if (saved) {
       try {
         const parsed = JSON.parse(saved);
@@ -18,7 +18,7 @@ export default function useNewEntryForm(setEntries, addToast) {
           symptomStrength: strength,
           tagColor: parsed.tagColor || TAG_COLORS.GREEN,
           tagColorManual: parsed.tagColorManual || false,
-          portion: parsed.portion || { size: 'M', grams: null },
+          portion: parsed.portion || { size: null, grams: null },
         };
       } catch {
         return initialForm;
@@ -92,7 +92,7 @@ export default function useNewEntryForm(setEntries, addToast) {
       portion: newForm.portion,
     };
     setEntries(prev => [...prev, entry].sort(sortEntries));
-    setNewForm({ food: '', imgs: [], symptomInput: '', symptomTime: 0, symptomStrength: 1, tagColor: TAG_COLORS.GREEN, tagColorManual: false, portion: { size: 'M', grams: null } });
+    setNewForm({ food: '', imgs: [], symptomInput: '', symptomTime: 0, symptomStrength: 1, tagColor: TAG_COLORS.GREEN, tagColorManual: false, portion: { size: null, grams: null } });
     setNewSymptoms([]);
     addToast(t('Eintrag gespeichert'));
     vibrate(50);

--- a/src/styles.js
+++ b/src/styles.js
@@ -332,7 +332,14 @@ const styles = {
     fontSize: '16px',
     fontWeight: 600,
     cursor: 'pointer',
-    color: size === 'S' ? '#8bc34a' : size === 'M' ? '#ffb74d' : '#e57373',
+    color:
+      size === 'S'
+        ? '#8bc34a'
+        : size === 'M'
+        ? '#ffb74d'
+        : size === 'L'
+        ? '#e57373'
+        : '#999',
   }),
   portionPickerPopup: (dark, openLeft = false) => ({
     position: 'absolute',

--- a/src/translations.js
+++ b/src/translations.js
@@ -90,7 +90,8 @@ const translations = {
     'Portion wählen': 'Select portion',
     'Benutzerdefiniert': 'Custom',
     'Gramm': 'grams',
-    'Portion geändert': 'Portion updated'
+    'Portion geändert': 'Portion updated',
+    'Portion entfernen': 'Remove portion'
   },
   de: {
     'Export': 'Exportieren',
@@ -103,7 +104,8 @@ const translations = {
     'Portion wählen': 'Portion wählen',
     'Benutzerdefiniert': 'Benutzerdefiniert',
     'Gramm': 'Gramm',
-    'Portion geändert': 'Portion geändert'
+    'Portion geändert': 'Portion geändert',
+    'Portion entfernen': 'Portion entfernen'
   }
 };
 


### PR DESCRIPTION
## Summary
- make portion optional in state and UI
- update translations for removing portion
- add remove option in portion menus
- tweak styling for empty portion labels

## Testing
- `node --check src/components/NewEntryForm.js`
- `node --check src/components/EntryCard.js`
- `node --check src/App.js`
- `node --check src/hooks/useNewEntryForm.js`
- `node --check src/translations.js`
- `node --check src/styles.js`


------
https://chatgpt.com/codex/tasks/task_e_684f171304e88332b1885a6b8ee0e677