### PR TITLE
Improve edit mode layout

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -513,20 +513,20 @@ export default function App() {
     });
   };
 
-  const toggleFavoriteFood = (food) => {
+  const toggleFavoriteFood = food => {
     setFavoriteFoods(favs => {
       const exists = favs.includes(food);
       const newSet = exists ? favs.filter(f => f !== food) : [...favs, food];
-      if (!exists) addToast(t('Zu Favoriten hinzugefügt'));
+      addToast(t(exists ? 'Aus Favoriten entfernt' : 'Zu Favoriten hinzugefügt'));
       return newSet.sort((a, b) => a.localeCompare(b));
     });
   };
 
-  const toggleFavoriteSymptom = (sym) => {
+  const toggleFavoriteSymptom = sym => {
     setFavoriteSymptoms(favs => {
       const exists = favs.includes(sym);
       const newSet = exists ? favs.filter(s => s !== sym) : [...favs, sym];
-      if (!exists) addToast(t('Zu Favoriten hinzugefügt'));
+      addToast(t(exists ? 'Aus Favoriten entfernt' : 'Zu Favoriten hinzugefügt'));
       return newSet.sort((a, b) => a.localeCompare(b));
     });
   };

--- a/src/App.js
+++ b/src/App.js
@@ -515,14 +515,18 @@ export default function App() {
 
   const toggleFavoriteFood = (food) => {
     setFavoriteFoods(favs => {
-      const newSet = favs.includes(food) ? favs.filter(f => f !== food) : [...favs, food];
+      const exists = favs.includes(food);
+      const newSet = exists ? favs.filter(f => f !== food) : [...favs, food];
+      if (!exists) addToast(t('Zu Favoriten hinzugefügt'));
       return newSet.sort((a, b) => a.localeCompare(b));
     });
   };
 
   const toggleFavoriteSymptom = (sym) => {
     setFavoriteSymptoms(favs => {
-      const newSet = favs.includes(sym) ? favs.filter(s => s !== sym) : [...favs, sym];
+      const exists = favs.includes(sym);
+      const newSet = exists ? favs.filter(s => s !== sym) : [...favs, sym];
+      if (!exists) addToast(t('Zu Favoriten hinzugefügt'));
       return newSet.sort((a, b) => a.localeCompare(b));
     });
   };

--- a/src/components/EntryCard.js
+++ b/src/components/EntryCard.js
@@ -63,6 +63,7 @@ export default function EntryCard({
     entry.portion?.size === 'custom' ? entry.portion.grams || '' : ''
   );
   const [showDateInput, setShowDateInput] = useState(false);
+  const dateInputRef = useRef(null);
   const lastFoodTapRef = useRef(0);
   const lastSymptomInputTapRef = useRef(0);
   const lastSymptomTapRefs = useRef({});
@@ -102,6 +103,12 @@ export default function EntryCard({
       entry.portion?.size === 'custom' ? entry.portion.grams || '' : ''
     );
   }, [entry.portion]);
+
+  useEffect(() => {
+    if (showDateInput) {
+      dateInputRef.current?.focus();
+    }
+  }, [showDateInput]);
   const isSymptomOnlyEntry = !entry.food && (entry.symptoms || []).length > 0;
   const sortedAllDisplay = sortSymptomsByTime(
     (entry.symptoms || []).map(s => ({
@@ -271,6 +278,7 @@ export default function EntryCard({
             </button>
             {showDateInput && (
               <input
+                ref={dateInputRef}
                 type="datetime-local"
                 value={editForm.date}
                 onChange={e => setEditForm(fm => ({ ...fm, date: e.target.value }))}

--- a/src/components/EntryCard.js
+++ b/src/components/EntryCard.js
@@ -68,26 +68,32 @@ export default function EntryCard({
   const lastSymptomTapRefs = useRef({});
   const DOUBLE_TAP_MS = 350;
 
-  const handleFoodTap = () => {
+  const handleFoodTap = e => {
     const now = Date.now();
     if (now - lastFoodTapRef.current < DOUBLE_TAP_MS) {
       toggleFavoriteFood(editForm.food.trim());
+      e.target.blur();
+      e.preventDefault();
     }
     lastFoodTapRef.current = now;
   };
 
-  const handleNewSymptomTap = () => {
+  const handleNewSymptomTap = e => {
     const now = Date.now();
     if (now - lastSymptomInputTapRef.current < DOUBLE_TAP_MS) {
       toggleFavoriteSymptom(editForm.symptomInput.trim());
+      e.target.blur();
+      e.preventDefault();
     }
     lastSymptomInputTapRef.current = now;
   };
 
-  const handleSymptomTap = (j, text) => {
+  const handleSymptomTap = (e, j, text) => {
     const now = Date.now();
     if (now - (lastSymptomTapRefs.current[j] || 0) < DOUBLE_TAP_MS) {
       toggleFavoriteSymptom(text.trim());
+      e.target.blur();
+      e.preventDefault();
     }
     lastSymptomTapRefs.current[j] = now;
   };
@@ -413,7 +419,7 @@ export default function EntryCard({
                         )
                       }))
                     }
-                    onClick={() => handleSymptomTap(j, s.txt)}
+                    onClick={e => handleSymptomTap(e, j, s.txt)}
                     onFocus={handleFocus}
                     style={{ ...styles.smallInput, flexGrow: 1, marginRight: '6px' }}
                   />

--- a/src/components/EntryCard.js
+++ b/src/components/EntryCard.js
@@ -223,112 +223,106 @@ export default function EntryCard({
           >
             ×
           </button>
-          <input
-            type="datetime-local"
-            value={editForm.date}
-            onChange={e => setEditForm(fm => ({ ...fm, date: e.target.value }))}
-            style={{
-              ...styles.input,
-              display: 'inline-block',
-              marginBottom: '12px',
-              width: 'fit-content',
-              marginRight: showPortion ? '70px' : 0
-            }}
-          />
-          <div style={{ display: 'flex', alignItems: 'center', gap: '4px', marginBottom: '8px' }}>
-            <div id="edit-food-input-container" style={{ position: 'relative', flexGrow: 1 }}>
-              <input
-                placeholder={t('Eintrag...')}
-                value={editForm.food}
-                onChange={e => setEditForm(fm => ({ ...fm, food: e.target.value }))}
-                onFocus={handleFocus}
-                style={{ ...styles.input, flexGrow: 1, width: '100%', paddingRight: '30px' }}
-              />
-              <button
-                className="quick-arrow"
-                onClick={() => setShowEditFoodQuick(s => !s)}
-                style={{
-                  ...styles.glassyIconButton(dark),
-                  padding: '4px',
-                  position: 'absolute',
-                  top: 'calc(50% - 2px)',
-                  right: '6px',
-                  transform: 'translateY(-50%)',
-                  color: '#333'
-                }}
-                title={t('Favoriten')}
-              >
-                ▼
-              </button>
-              {showEditFoodQuick && (
-                <QuickMenu
-                  items={favoriteFoods}
-                  onSelect={f => {
-                    setEditForm(fm => ({ ...fm, food: f }));
-                    setShowEditFoodQuick(false);
-                  }}
-                  style={{ top: '32px', left: 0 }}
-                />
-              )}
-            </div>
-            <button
-              onClick={() => toggleFavoriteFood(editForm.food.trim())}
-              title={t('Favorit')}
-              style={{ background: 'transparent', border: 'none', cursor: 'pointer', fontSize: 20, color: favoriteFoods.includes(editForm.food.trim()) ? '#FBC02D' : '#aaa' }}
-            >
-              ★
-            </button>
-            <CameraButton onClick={() => fileRefEdit.current?.click()} dark={dark} />
+          <div style={styles.editForm}>
             <input
-              ref={fileRefEdit}
-              type="file"
-              accept="image/*"
-              multiple
-              capture={isMobile ? 'environment' : undefined}
-              onChange={handleEditFile}
-              style={{ display: 'none' }}
+              type="datetime-local"
+              value={editForm.date}
+              onChange={e => setEditForm(fm => ({ ...fm, date: e.target.value }))}
+              style={{ ...styles.input, width: 'fit-content', marginRight: showPortion ? '70px' : 0 }}
             />
-            {editForm.imgs.length > 0 && <ImgStack imgs={editForm.imgs} onDelete={removeEditImg} />}
-          </div>
-
-          <div style={{ marginBottom: 12 }}>
-            <div id="edit-symptom-input-container" style={{ position: 'relative', marginBottom: '8px' }}>
-              <input
-                className="hide-datalist-arrow"
-                placeholder={t('Symptom hinzufügen...')}
-                value={editForm.symptomInput}
-                onChange={e => setEditForm(fm => ({ ...fm, symptomInput: e.target.value }))}
-                onFocus={handleFocus}
-                style={{ ...styles.smallInput, width: '100%', paddingRight: '30px' }}
-              />
-              <button
-                className="quick-arrow"
-                onClick={() => setShowEditSymptomQuick(s => !s)}
-                style={{
-                  ...styles.glassyIconButton(dark),
-                  padding: '4px',
-                  position: 'absolute',
-                  top: '50%',
-                  right: '6px',
-                  transform: 'translateY(-50%)',
-                  color: '#333'
-                }}
-                title={t('Favoriten')}
-              >
-                ▼
-              </button>
-              {showEditSymptomQuick && (
-                <QuickMenu
-                  items={favoriteSymptoms}
-                  onSelect={sym => {
-                    setEditForm(fm => ({ ...fm, symptomInput: sym }));
-                    setShowEditSymptomQuick(false);
-                  }}
-                  style={{ top: '32px', left: 0 }}
+            <div style={styles.editRow}>
+              <div id="edit-food-input-container" style={{ position: 'relative', flexGrow: 1 }}>
+                <input
+                  placeholder={t('Eintrag...')}
+                  value={editForm.food}
+                  onChange={e => setEditForm(fm => ({ ...fm, food: e.target.value }))}
+                  onFocus={handleFocus}
+                  style={{ ...styles.input, flexGrow: 1, width: '100%', paddingRight: '30px' }}
                 />
-              )}
+                <button
+                  className="quick-arrow"
+                  onClick={() => setShowEditFoodQuick(s => !s)}
+                  style={{
+                    ...styles.glassyIconButton(dark),
+                    padding: '4px',
+                    position: 'absolute',
+                    top: 'calc(50% - 2px)',
+                    right: '6px',
+                    transform: 'translateY(-50%)',
+                    color: '#333'
+                  }}
+                  title={t('Favoriten')}
+                >
+                  ▼
+                </button>
+                {showEditFoodQuick && (
+                  <QuickMenu
+                    items={favoriteFoods}
+                    onSelect={f => {
+                      setEditForm(fm => ({ ...fm, food: f }));
+                      setShowEditFoodQuick(false);
+                    }}
+                    style={{ top: '32px', left: 0 }}
+                  />
+                )}
+              </div>
+              <button
+                onClick={() => toggleFavoriteFood(editForm.food.trim())}
+                title={t('Favorit')}
+                style={{ background: 'transparent', border: 'none', cursor: 'pointer', fontSize: 20, color: favoriteFoods.includes(editForm.food.trim()) ? '#FBC02D' : '#aaa' }}
+              >
+                ★
+              </button>
+              <CameraButton onClick={() => fileRefEdit.current?.click()} dark={dark} />
+              <input
+                ref={fileRefEdit}
+                type="file"
+                accept="image/*"
+                multiple
+                capture={isMobile ? 'environment' : undefined}
+                onChange={handleEditFile}
+                style={{ display: 'none' }}
+              />
+              {editForm.imgs.length > 0 && <ImgStack imgs={editForm.imgs} onDelete={removeEditImg} />}
             </div>
-            <div style={{ display: 'flex', alignItems: 'center', gap: '6px', flexWrap: 'nowrap' }}>
+
+            <div style={styles.editRow}>
+              <div id="edit-symptom-input-container" style={{ position: 'relative', flexGrow: 1 }}>
+                <input
+                  className="hide-datalist-arrow"
+                  placeholder={t('Symptom hinzufügen...')}
+                  value={editForm.symptomInput}
+                  onChange={e => setEditForm(fm => ({ ...fm, symptomInput: e.target.value }))}
+                  onFocus={handleFocus}
+                  style={{ ...styles.smallInput, width: '100%', paddingRight: '30px' }}
+                />
+                <button
+                  className="quick-arrow"
+                  onClick={() => setShowEditSymptomQuick(s => !s)}
+                  style={{
+                    ...styles.glassyIconButton(dark),
+                    padding: '4px',
+                    position: 'absolute',
+                    top: '50%',
+                    right: '6px',
+                    transform: 'translateY(-50%)',
+                    color: '#333'
+                  }}
+                  title={t('Favoriten')}
+                >
+                  ▼
+                </button>
+                {showEditSymptomQuick && (
+                  <QuickMenu
+                    items={favoriteSymptoms}
+                    onSelect={sym => {
+                      setEditForm(fm => ({ ...fm, symptomInput: sym }));
+                      setShowEditSymptomQuick(false);
+                    }}
+                    style={{ top: '32px', left: 0 }}
+                  />
+                )}
+              </div>
               <select
                 value={editForm.symptomTime}
                 onChange={e => setEditForm(fm => ({ ...fm, symptomTime: Number(e.target.value) }))}
@@ -357,124 +351,125 @@ export default function EntryCard({
                 +
               </button>
             </div>
-          </div>
 
-          <div style={{ marginBottom: 8 }}>
+            <div style={styles.editRow}>
               {sortSymptomsByTime(editForm.symptoms).map((s, j) => (
-              <div
-                key={j}
-                style={{ display: 'flex', alignItems: 'center', gap: '6px', marginBottom: '8px', flexWrap: 'nowrap' }}
-              >
-                <input
-                  type="text"
-                  className="hide-datalist-arrow"
-                  value={s.txt}
-                  onChange={e_text =>
-                    setEditForm(fm => ({
-                      ...fm,
-                      symptoms: fm.symptoms.map((sym, k) =>
-                        k === j ? { ...sym, txt: e_text.target.value } : sym
-                      )
-                    }))
-                  }
-                  onFocus={handleFocus}
-                  style={{ ...styles.smallInput, flexGrow: 1, marginRight: '6px' }}
-                />
-                <button
-                  onClick={() => toggleFavoriteSymptom(s.txt)}
-                  title={t('Favorit')}
-                  style={{ background: 'transparent', border: 'none', cursor: 'pointer', fontSize: 18, color: favoriteSymptoms.includes(s.txt) ? '#FBC02D' : '#aaa' }}
+                <div
+                  key={j}
+                  style={{ display: 'flex', alignItems: 'center', gap: '6px', flexWrap: 'nowrap' }}
                 >
-                  ★
-                </button>
-                <select
-                  value={s.time}
-                  onChange={e_select =>
-                    setEditForm(fm => {
-                      const updated = fm.symptoms.map((sym, k) =>
-                        k === j ? { ...sym, time: Number(e_select.target.value) } : sym
-                      );
-                      return { ...fm, symptoms: sortSymptomsByTime(updated) };
-                    })
-                  }
-                  style={{ ...styles.smallInput, width: '32px', flexShrink: 0, fontSize: '16px', padding: '6px 2px' }}
-                >
-                  {TIME_CHOICES.map(t => (
-                    <option key={t.value} value={t.value}>
-                      {t.value === 0 ? '0' : t.value}
-                    </option>
-                  ))}
-                </select>
-                <select
-                  value={s.strength || 1}
-                  onChange={e_strength =>
-                    setEditForm(fm => ({
-                      ...fm,
-                      symptoms: fm.symptoms.map((sym, k) =>
-                        k === j ? { ...sym, strength: Number(e_strength.target.value) } : sym
-                      )
-                    }))
-                  }
-                  style={{ ...styles.smallInput, width: '25px', flexShrink: 0, fontSize: '16px', padding: '6px 2px' }}
-                >
-                  {[1, 2, 3].map(n => (
-                    <option key={n} value={n}>
-                      {n}
-                    </option>
-                  ))}
-                </select>
-                <button
-                  onClick={() => removeEditSymptom(j)}
-                  title={t('Symptom löschen')}
-                  style={{ ...styles.deleteIcon, position: 'static', fontSize: '20px' }}
-                >
-                  ×
-                </button>
-              </div>
-            ))}
-          </div>
-          <div style={{ display: 'flex', gap: 5, marginTop: '16px', alignItems: 'center' }}>
-            <button onClick={saveEdit} style={styles.buttonSecondary('#1976d2')}>
-              {t('Speichern')}
-            </button>
-            <button onClick={cancelEdit} style={styles.buttonSecondary('#888')}>
-              {t('Abbrechen')}
-            </button>
-            <button
-              id={`note-icon-button-${idx}`}
-              onClick={e => {
-                e.stopPropagation();
-                toggleNote(idx);
-              }}
-              style={{ ...styles.glassyIconButton(dark), padding: '6px' }}
-              title={t('Notiz')}
-            >
-              🗒️
-            </button>
-          </div>
+                  <input
+                    type="text"
+                    className="hide-datalist-arrow"
+                    value={s.txt}
+                    onChange={e_text =>
+                      setEditForm(fm => ({
+                        ...fm,
+                        symptoms: fm.symptoms.map((sym, k) =>
+                          k === j ? { ...sym, txt: e_text.target.value } : sym
+                        )
+                      }))
+                    }
+                    onFocus={handleFocus}
+                    style={{ ...styles.smallInput, flexGrow: 1, marginRight: '6px' }}
+                  />
+                  <button
+                    onClick={() => toggleFavoriteSymptom(s.txt)}
+                    title={t('Favorit')}
+                    style={{ background: 'transparent', border: 'none', cursor: 'pointer', fontSize: 18, color: favoriteSymptoms.includes(s.txt) ? '#FBC02D' : '#aaa' }}
+                  >
+                    ★
+                  </button>
+                  <select
+                    value={s.time}
+                    onChange={e_select =>
+                      setEditForm(fm => {
+                        const updated = fm.symptoms.map((sym, k) =>
+                          k === j ? { ...sym, time: Number(e_select.target.value) } : sym
+                        );
+                        return { ...fm, symptoms: sortSymptomsByTime(updated) };
+                      })
+                    }
+                    style={{ ...styles.smallInput, width: '32px', flexShrink: 0, fontSize: '16px', padding: '6px 2px' }}
+                  >
+                    {TIME_CHOICES.map(t => (
+                      <option key={t.value} value={t.value}>
+                        {t.value === 0 ? '0' : t.value}
+                      </option>
+                    ))}
+                  </select>
+                  <select
+                    value={s.strength || 1}
+                    onChange={e_strength =>
+                      setEditForm(fm => ({
+                        ...fm,
+                        symptoms: fm.symptoms.map((sym, k) =>
+                          k === j ? { ...sym, strength: Number(e_strength.target.value) } : sym
+                        )
+                      }))
+                    }
+                    style={{ ...styles.smallInput, width: '25px', flexShrink: 0, fontSize: '16px', padding: '6px 2px' }}
+                  >
+                    {[1, 2, 3].map(n => (
+                      <option key={n} value={n}>
+                        {n}
+                      </option>
+                    ))}
+                  </select>
+                  <button
+                    onClick={() => removeEditSymptom(j)}
+                    title={t('Symptom löschen')}
+                    style={{ ...styles.deleteIcon, position: 'static', fontSize: '20px' }}
+                  >
+                    ×
+                  </button>
+                </div>
+              ))}
+            </div>
 
-          {noteOpenIdx === idx && !isExportingPdf && (
-            <div onClick={e => e.stopPropagation()} style={{ marginTop: '8px', zIndex: 15 }}>
-              <textarea
-                id={`note-textarea-${idx}`}
-                value={noteDraft}
-                onChange={e => {
-                  setNoteDraft(e.target.value);
-                  e.target.style.height = 'auto';
-                  e.target.style.height = `${e.target.scrollHeight}px`;
-                }}
-                placeholder={t('Notiz...')}
-                style={{ ...styles.textarea, fontSize: '16px' }}
-              />
+            <div style={styles.editRow}>
+              <button onClick={saveEdit} style={styles.buttonSecondary('#1976d2')}>
+                {t('Speichern')}
+              </button>
+              <button onClick={cancelEdit} style={styles.buttonSecondary('#888')}>
+                {t('Abbrechen')}
+              </button>
               <button
-                id={`note-save-button-${idx}`}
-                onClick={() => saveNote(idx)}
-                style={{ ...styles.buttonSecondary(dark ? '#555' : '#FBC02D'), color: dark ? '#fff' : '#333', marginTop: 8 }}
+                id={`note-icon-button-${idx}`}
+                onClick={e => {
+                  e.stopPropagation();
+                  toggleNote(idx);
+                }}
+                style={{ ...styles.glassyIconButton(dark), padding: '6px' }}
+                title={t('Notiz')}
               >
-                {t('Notiz speichern')}
+                🗒️
               </button>
             </div>
-          )}
+
+            {noteOpenIdx === idx && !isExportingPdf && (
+              <div onClick={e => e.stopPropagation()} style={{ zIndex: 15 }}>
+                <textarea
+                  id={`note-textarea-${idx}`}
+                  value={noteDraft}
+                  onChange={e => {
+                    setNoteDraft(e.target.value);
+                    e.target.style.height = 'auto';
+                    e.target.style.height = `${e.target.scrollHeight}px`;
+                  }}
+                  placeholder={t('Notiz...')}
+                  style={{ ...styles.textarea, fontSize: '16px' }}
+                />
+                <button
+                  id={`note-save-button-${idx}`}
+                  onClick={() => saveNote(idx)}
+                  style={{ ...styles.buttonSecondary(dark ? '#555' : '#FBC02D'), color: dark ? '#fff' : '#333', marginTop: 8 }}
+                >
+                  {t('Notiz speichern')}
+                </button>
+              </div>
+            )}
+          </div>
         </>
       ) : (
         <>

--- a/src/components/EntryCard.js
+++ b/src/components/EntryCard.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import useTranslation from '../useTranslation';
 import { PORTION_COLORS } from '../constants';
 
@@ -62,6 +62,35 @@ export default function EntryCard({
   const [quickGrams, setQuickGrams] = useState(
     entry.portion?.size === 'custom' ? entry.portion.grams || '' : ''
   );
+  const [showDateInput, setShowDateInput] = useState(false);
+  const lastFoodTapRef = useRef(0);
+  const lastSymptomInputTapRef = useRef(0);
+  const lastSymptomTapRefs = useRef({});
+  const DOUBLE_TAP_MS = 350;
+
+  const handleFoodTap = () => {
+    const now = Date.now();
+    if (now - lastFoodTapRef.current < DOUBLE_TAP_MS) {
+      toggleFavoriteFood(editForm.food.trim());
+    }
+    lastFoodTapRef.current = now;
+  };
+
+  const handleNewSymptomTap = () => {
+    const now = Date.now();
+    if (now - lastSymptomInputTapRef.current < DOUBLE_TAP_MS) {
+      toggleFavoriteSymptom(editForm.symptomInput.trim());
+    }
+    lastSymptomInputTapRef.current = now;
+  };
+
+  const handleSymptomTap = (j, text) => {
+    const now = Date.now();
+    if (now - (lastSymptomTapRefs.current[j] || 0) < DOUBLE_TAP_MS) {
+      toggleFavoriteSymptom(text.trim());
+    }
+    lastSymptomTapRefs.current[j] = now;
+  };
   useEffect(() => {
     setQuickGrams(
       entry.portion?.size === 'custom' ? entry.portion.grams || '' : ''
@@ -223,19 +252,32 @@ export default function EntryCard({
           >
             ×
           </button>
+          <button
+            onClick={e => {
+              e.stopPropagation();
+              setShowDateInput(s => !s);
+            }}
+            style={{ ...styles.glassyIconButton(dark), position: 'absolute', top: 8, left: 8, padding: '6px' }}
+            title={t('Datum / Zeit ändern')}
+          >
+            📅
+          </button>
           <div style={styles.editForm}>
-            <input
-              type="datetime-local"
-              value={editForm.date}
-              onChange={e => setEditForm(fm => ({ ...fm, date: e.target.value }))}
-              style={{ ...styles.input, width: 'fit-content', marginRight: showPortion ? '70px' : 0 }}
-            />
+            {showDateInput && (
+              <input
+                type="datetime-local"
+                value={editForm.date}
+                onChange={e => setEditForm(fm => ({ ...fm, date: e.target.value }))}
+                style={{ ...styles.input, width: 'fit-content', marginRight: showPortion ? '70px' : 0 }}
+              />
+            )}
             <div style={styles.editRow}>
               <div id="edit-food-input-container" style={{ position: 'relative', flexGrow: 1 }}>
                 <input
                   placeholder={t('Eintrag...')}
                   value={editForm.food}
                   onChange={e => setEditForm(fm => ({ ...fm, food: e.target.value }))}
+                  onClick={handleFoodTap}
                   onFocus={handleFocus}
                   style={{ ...styles.input, flexGrow: 1, width: '100%', paddingRight: '30px' }}
                 />
@@ -293,6 +335,7 @@ export default function EntryCard({
                   placeholder={t('Symptom hinzufügen...')}
                   value={editForm.symptomInput}
                   onChange={e => setEditForm(fm => ({ ...fm, symptomInput: e.target.value }))}
+                  onClick={handleNewSymptomTap}
                   onFocus={handleFocus}
                   style={{ ...styles.smallInput, width: '100%', paddingRight: '30px' }}
                 />
@@ -370,6 +413,7 @@ export default function EntryCard({
                         )
                       }))
                     }
+                    onClick={() => handleSymptomTap(j, s.txt)}
                     onFocus={handleFocus}
                     style={{ ...styles.smallInput, flexGrow: 1, marginRight: '6px' }}
                   />

--- a/src/components/EntryCard.js
+++ b/src/components/EntryCard.js
@@ -328,13 +328,6 @@ export default function EntryCard({
                 />
               )}
             </div>
-            <button
-              onClick={() => toggleFavoriteFood(editForm.food.trim())}
-              title={t('Favorit')}
-              style={{ background: 'transparent', border: 'none', cursor: 'pointer', fontSize: 20, color: favoriteFoods.includes(editForm.food.trim()) ? '#FBC02D' : '#aaa' }}
-            >
-              ★
-            </button>
             <CameraButton onClick={() => fileRefEdit.current?.click()} dark={dark} />
             <input
               ref={fileRefEdit}
@@ -439,13 +432,6 @@ export default function EntryCard({
                   onFocus={handleFocus}
                   style={{ ...styles.smallInput, flexGrow: 1, marginRight: '6px' }}
                 />
-                <button
-                  onClick={() => toggleFavoriteSymptom(s.txt)}
-                  title={t('Favorit')}
-                  style={{ background: 'transparent', border: 'none', cursor: 'pointer', fontSize: 18, color: favoriteSymptoms.includes(s.txt) ? '#FBC02D' : '#aaa' }}
-                >
-                  ★
-                </button>
                 <select
                   value={s.time}
                   onChange={e_select =>

--- a/src/components/EntryCard.js
+++ b/src/components/EntryCard.js
@@ -291,7 +291,7 @@ export default function EntryCard({
               }}
             />
           )}
-          <div style={{ display: 'flex', alignItems: 'center', gap: '4px', marginBottom: '15px' }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: '4px', marginBottom: '40px' }}>
             <div id="edit-food-input-container" style={{ position: 'relative', flexGrow: 1 }}>
               <input
                 placeholder={t('Eintrag...')}

--- a/src/components/EntryCard.js
+++ b/src/components/EntryCard.js
@@ -258,17 +258,17 @@ export default function EntryCard({
           >
             ×
           </button>
-          <button
-            onClick={e => {
-              e.stopPropagation();
-              setShowDateInput(s => !s);
-            }}
-            style={{ ...styles.glassyIconButton(dark), position: 'absolute', top: 8, left: 8, padding: '6px' }}
-            title={t('Datum / Zeit ändern')}
-          >
-            📅
-          </button>
           <div style={styles.editForm}>
+            <button
+              onClick={e => {
+                e.stopPropagation();
+                setShowDateInput(s => !s);
+              }}
+              style={{ ...styles.glassyIconButton(dark), alignSelf: 'flex-start', padding: '6px', marginBottom: '8px' }}
+              title={t('Datum / Zeit ändern')}
+            >
+              📅
+            </button>
             {showDateInput && (
               <input
                 type="datetime-local"

--- a/src/components/EntryCard.js
+++ b/src/components/EntryCard.js
@@ -168,7 +168,7 @@ export default function EntryCard({
         </div>
       </div>
       {showPortion && (
-        <div style={styles.portionContainer()}>
+        <div style={styles.portionContainer(editingIdx === idx)}>
           <div
             id={`portion-label-${idx}`}
             style={styles.portionLabel(

--- a/src/components/EntryCard.js
+++ b/src/components/EntryCard.js
@@ -106,7 +106,10 @@ export default function EntryCard({
 
   useEffect(() => {
     if (showDateInput) {
-      dateInputRef.current?.focus();
+      const input = dateInputRef.current;
+      input?.focus();
+      // open the browser picker immediately when revealing the input
+      input?.showPicker?.();
     }
   }, [showDateInput]);
   const isSymptomOnlyEntry = !entry.food && (entry.symptoms || []).length > 0;

--- a/src/styles.js
+++ b/src/styles.js
@@ -365,18 +365,6 @@ const styles = {
     background: isActive ? (dark ? '#555' : '#eee') : 'transparent',
     color,
   }),
-  editForm: {
-    display: 'flex',
-    flexDirection: 'column',
-    gap: '10px',
-    marginTop: '8px',
-  },
-  editRow: {
-    display: 'flex',
-    flexWrap: 'wrap',
-    alignItems: 'center',
-    gap: '6px',
-  },
   personInfoBox: (dark) => ({
     display: 'flex',
     flexWrap: 'wrap',

--- a/src/styles.js
+++ b/src/styles.js
@@ -370,7 +370,6 @@ const styles = {
     flexDirection: 'column',
     gap: '8px',
     marginTop: '8px',
-    paddingLeft: '36px',
   },
   editRow: {
     display: 'flex',

--- a/src/styles.js
+++ b/src/styles.js
@@ -318,10 +318,10 @@ const styles = {
     overflow: 'visible',
     cursor: 'pointer',
   },
-  portionContainer: () => ({
+  portionContainer: (editing = false) => ({
     position: 'absolute',
-    top: '36px',
-    right: '38px',
+    top: editing ? '31px' : '36px',
+    right: editing ? '33px' : '38px',
     transform: 'translateY(-50%)',
     display: 'flex',
     alignItems: 'center',

--- a/src/styles.js
+++ b/src/styles.js
@@ -370,6 +370,7 @@ const styles = {
     flexDirection: 'column',
     gap: '8px',
     marginTop: '8px',
+    paddingLeft: '36px',
   },
   editRow: {
     display: 'flex',

--- a/src/styles.js
+++ b/src/styles.js
@@ -368,7 +368,7 @@ const styles = {
   editForm: {
     display: 'flex',
     flexDirection: 'column',
-    gap: '8px',
+    gap: '10px',
     marginTop: '8px',
   },
   editRow: {

--- a/src/styles.js
+++ b/src/styles.js
@@ -365,6 +365,18 @@ const styles = {
     background: isActive ? (dark ? '#555' : '#eee') : 'transparent',
     color,
   }),
+  editForm: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '8px',
+    marginTop: '8px',
+  },
+  editRow: {
+    display: 'flex',
+    flexWrap: 'wrap',
+    alignItems: 'center',
+    gap: '6px',
+  },
   personInfoBox: (dark) => ({
     display: 'flex',
     flexWrap: 'wrap',

--- a/src/translations.js
+++ b/src/translations.js
@@ -56,6 +56,7 @@ const translations = {
     'Verknüpfung entfernen?': 'Remove link?',
     'Theme wechseln': 'Toggle theme',
     'Favorit': 'Favorite',
+    'Zu Favoriten hinzugefügt': 'Added to favorites',
     'Expand day': 'Expand day',
     'Collapse day': 'Collapse day',
     'Klicken zum Ändern.': 'Click to change',
@@ -105,7 +106,8 @@ const translations = {
     'Benutzerdefiniert': 'Benutzerdefiniert',
     'Gramm': 'Gramm',
     'Portion geändert': 'Portion geändert',
-    'Portion entfernen': 'Portion entfernen'
+    'Portion entfernen': 'Portion entfernen',
+    'Zu Favoriten hinzugefügt': 'Zu Favoriten hinzugefügt'
   }
 };
 

--- a/src/translations.js
+++ b/src/translations.js
@@ -57,6 +57,7 @@ const translations = {
     'Theme wechseln': 'Toggle theme',
     'Favorit': 'Favorite',
     'Zu Favoriten hinzugefügt': 'Added to favorites',
+    'Aus Favoriten entfernt': 'Removed from favorites',
     'Expand day': 'Expand day',
     'Collapse day': 'Collapse day',
     'Klicken zum Ändern.': 'Click to change',
@@ -107,7 +108,8 @@ const translations = {
     'Gramm': 'Gramm',
     'Portion geändert': 'Portion geändert',
     'Portion entfernen': 'Portion entfernen',
-    'Zu Favoriten hinzugefügt': 'Zu Favoriten hinzugefügt'
+    'Zu Favoriten hinzugefügt': 'Zu Favoriten hinzugefügt',
+    'Aus Favoriten entfernt': 'Aus Favoriten entfernt'
   }
 };
 


### PR DESCRIPTION
## Summary
- restructure entry editing layout for clarity
- add shared styles for edit container and rows

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684fac0371ac8332b24c8dbaaeade4de