### PR TITLE
Remove frosted glass from portion display

### DIFF
--- a/src/components/EntryCard.js
+++ b/src/components/EntryCard.js
@@ -116,7 +116,11 @@ export default function EntryCard({
       if (cardEl && rowEl) {
         const cardRect = cardEl.getBoundingClientRect();
         const rowRect = rowEl.getBoundingClientRect();
-        setIconTop(rowRect.top - cardRect.top + rowRect.height / 2);
+        const firstLine = rowEl.getClientRects()[0] || rowRect;
+        const lineHeight = parseFloat(
+          window.getComputedStyle(rowEl).lineHeight || firstLine.height
+        );
+        setIconTop(firstLine.top - cardRect.top + lineHeight / 2);
       }
     };
     update();

--- a/src/components/EntryCard.js
+++ b/src/components/EntryCard.js
@@ -115,12 +115,8 @@ export default function EntryCard({
       const rowEl = firstRowRef.current;
       if (cardEl && rowEl) {
         const cardRect = cardEl.getBoundingClientRect();
-        const rowRect = rowEl.getBoundingClientRect();
-        const firstLine = rowEl.getClientRects()[0] || rowRect;
-        const lineHeight = parseFloat(
-          window.getComputedStyle(rowEl).lineHeight || firstLine.height
-        );
-        setIconTop(firstLine.top - cardRect.top + lineHeight / 2);
+        const firstLine = rowEl.getClientRects()[0] || rowEl.getBoundingClientRect();
+        setIconTop(firstLine.top - cardRect.top + firstLine.height / 2);
       }
     };
     update();

--- a/src/components/EntryCard.js
+++ b/src/components/EntryCard.js
@@ -648,14 +648,16 @@ export default function EntryCard({
           )}
 
           <>
-            <div
-              id={`tag-marker-${idx}`}
-              style={styles.categoryIcon(editingIdx === idx ? '31px' : `${iconTop}px`)}
-              onClick={e => {
-                if (isExportingPdf) return;
-                e.stopPropagation();
-                setColorPickerOpenForIdx(colorPickerOpenForIdx === idx ? null : idx);
-                setNoteOpenIdx(null);
+          <div
+            id={`tag-marker-${idx}`}
+            style={styles.categoryIcon(
+              editingIdx === idx ? '31px' : `${iconTop - 4}px`
+            )}
+            onClick={e => {
+              if (isExportingPdf) return;
+              e.stopPropagation();
+              setColorPickerOpenForIdx(colorPickerOpenForIdx === idx ? null : idx);
+              setNoteOpenIdx(null);
               }}
               title={
                 !isExportingPdf

--- a/src/components/EntryCard.js
+++ b/src/components/EntryCard.js
@@ -188,7 +188,7 @@ export default function EntryCard({
           <button
             id={`portion-label-${idx}`}
             style={{
-              ...styles.glassyIconButton(dark),
+              ...(editingIdx === idx ? styles.glassyIconButton(dark) : styles.plainIconButton),
               ...styles.portionLabel(
                 currentPortion.size === 'custom' ? 'M' : currentPortion.size
               ),

--- a/src/components/EntryCard.js
+++ b/src/components/EntryCard.js
@@ -564,7 +564,6 @@ export default function EntryCard({
         <>
 
           <div
-            ref={firstRowRef}
             style={{
               fontSize: 12,
               opacity: 0.7,
@@ -582,6 +581,7 @@ export default function EntryCard({
             {(entry.date && entry.date.split(' ')[1]) || entry.date}
           </div>
           <div
+            ref={firstRowRef}
             style={{
               fontSize: 18,
               fontWeight: 600,

--- a/src/styles.js
+++ b/src/styles.js
@@ -288,16 +288,16 @@ const styles = {
     boxSizing: 'border-box',
     color: dark ? '#f0f0f8' : '#333',
   }),
-  categoryIcon: {
+  categoryIcon: (top = '36px') => ({
     position: 'absolute',
     // Align icon with main text line instead of overall card height
-    top: '36px',
+    top,
     right: '6px',
     transform: 'translateY(-50%)',
     fontSize: '20px',
     zIndex: 6,
     cursor: 'pointer',
-  },
+  }),
   pinContainer: {
     position: 'absolute',
     left: '0px',
@@ -330,9 +330,9 @@ const styles = {
     overflow: 'visible',
     cursor: 'pointer',
   },
-  portionContainer: (editing = false) => ({
+  portionContainer: (editing = false, top = '36px') => ({
     position: 'absolute',
-    top: editing ? '31px' : '36px',
+    top: editing ? '31px' : top,
     right: editing ? '12px' : '33px',
     transform: 'translateY(-50%)',
     display: 'flex',

--- a/src/styles.js
+++ b/src/styles.js
@@ -170,6 +170,18 @@ const styles = {
     alignItems: 'center',
     justifyContent: 'center',
   }),
+  plainIconButton: {
+    background: 'transparent',
+    border: 'none',
+    borderRadius: 6,
+    padding: '6px 8px',
+    cursor: 'pointer',
+    fontSize: 16,
+    lineHeight: 1,
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
   glassyButton: (dark) => ({
     background: dark ? 'rgba(255, 255, 255, 0.08)' : 'rgba(0, 0, 0, 0.04)',
     border: dark ? '1px solid rgba(255, 255, 255, 0.15)' : '1px solid rgba(0, 0, 0, 0.1)',
@@ -321,7 +333,7 @@ const styles = {
   portionContainer: (editing = false) => ({
     position: 'absolute',
     top: editing ? '31px' : '36px',
-    right: editing ? '12px' : '38px',
+    right: editing ? '12px' : '33px',
     transform: 'translateY(-50%)',
     display: 'flex',
     alignItems: 'center',


### PR DESCRIPTION
## Summary
- add `plainIconButton` style for transparent buttons
- shift portion container right margin for display mode
- use the new style when showing portion size outside of edit mode

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684fd570dc888332bbe863137231a543