### PR TITLE
Add category-colored borders

### DIFF
--- a/src/components/EntryCard.js
+++ b/src/components/EntryCard.js
@@ -2,6 +2,26 @@ import React, { useState, useEffect, useRef, useLayoutEffect } from 'react';
 import useTranslation from '../useTranslation';
 import { PORTION_COLORS } from '../constants';
 
+function lightenColor(color, factor = 0.5) {
+  const nameMap = {
+    green: '#4caf50',
+    red: '#f44336',
+    yellow: '#fbc02d',
+    gray: '#9e9e9e',
+  };
+  let hex = nameMap[color] || color;
+  hex = hex.replace('#', '');
+  if (hex.length === 3) hex = hex.split('').map(c => c + c).join('');
+  const num = parseInt(hex, 16);
+  let r = (num >> 16) & 255;
+  let g = (num >> 8) & 255;
+  let b = num & 255;
+  r = Math.round(r + (255 - r) * factor);
+  g = Math.round(g + (255 - g) * factor);
+  b = Math.round(b + (255 - b) * factor);
+  return `rgb(${r}, ${g}, ${b})`;
+}
+
 export default function EntryCard({
   entry,
   idx,
@@ -96,6 +116,7 @@ export default function EntryCard({
     : (dark ? styles.entryCard(dark, false).background : styles.entryCard(false, false).background);
 
   const currentTagColor = entry.tagColor || TAG_COLORS.GREEN;
+  const borderColor = lightenColor(currentTagColor, 0.5);
   const currentPortion =
     editingIdx === idx && editForm
       ? editForm.portion || { size: null, grams: null }
@@ -161,7 +182,10 @@ export default function EntryCard({
         refCallback(el);
       }}
       id={`entry-card-${idx}`}
-      style={{ ...styles.entryCard(dark, isSymptomOnlyEntry), marginBottom }}
+      style={{
+        ...styles.entryCard(dark, isSymptomOnlyEntry, borderColor),
+        marginBottom,
+      }}
       onClick={e => {
         if (isExportingPdf) return;
         e.stopPropagation();

--- a/src/components/EntryCard.js
+++ b/src/components/EntryCard.js
@@ -22,6 +22,48 @@ function lightenColor(color, factor = 0.3) {
   return `rgb(${r}, ${g}, ${b})`;
 }
 
+function hexToRgb(hex) {
+  hex = hex.replace('#', '');
+  if (hex.length === 3) hex = hex.split('').map(c => c + c).join('');
+  const num = parseInt(hex, 16);
+  return {
+    r: (num >> 16) & 255,
+    g: (num >> 8) & 255,
+    b: num & 255,
+  };
+}
+
+function rgbToHex({ r, g, b }) {
+  const toHex = n => n.toString(16).padStart(2, '0');
+  return `#${toHex(r)}${toHex(g)}${toHex(b)}`;
+}
+
+function mixHexColors(c1, c2) {
+  const rgb1 = hexToRgb(c1);
+  const rgb2 = hexToRgb(c2);
+  const mixed = {
+    r: Math.round((rgb1.r + rgb2.r) / 2),
+    g: Math.round((rgb1.g + rgb2.g) / 2),
+    b: Math.round((rgb1.b + rgb2.b) / 2),
+  };
+  return rgbToHex(mixed);
+}
+
+function getBorderColor(tagColor) {
+  const pairs = {
+    green: ['#4caf50', '#8bc34a'],
+    red: ['#f44336', '#b71c1c'],
+    yellow: ['#fbc02d', '#fff176'],
+    '#c19a6b': ['#c19a6b', '#8d6e63'],
+    '#64b5f6': ['#64b5f6', '#1e88e5'],
+    '#ba68c8': ['#ba68c8', '#9c27b0'],
+    gray: ['#9e9e9e', '#bdbdbd'],
+  };
+  const [c1, c2] = pairs[tagColor] || [tagColor, tagColor];
+  const mixed = mixHexColors(c1, c2);
+  return lightenColor(mixed, 0.3);
+}
+
 export default function EntryCard({
   entry,
   idx,
@@ -116,7 +158,7 @@ export default function EntryCard({
     : (dark ? styles.entryCard(dark, false).background : styles.entryCard(false, false).background);
 
   const currentTagColor = entry.tagColor || TAG_COLORS.GREEN;
-  const borderColor = lightenColor(currentTagColor, 0.3);
+  const borderColor = getBorderColor(currentTagColor);
   const currentPortion =
     editingIdx === idx && editForm
       ? editForm.portion || { size: null, grams: null }

--- a/src/components/EntryCard.js
+++ b/src/components/EntryCard.js
@@ -2,7 +2,7 @@ import React, { useState, useEffect, useRef, useLayoutEffect } from 'react';
 import useTranslation from '../useTranslation';
 import { PORTION_COLORS } from '../constants';
 
-function lightenColor(color, factor = 0.5) {
+function lightenColor(color, factor = 0.3) {
   const nameMap = {
     green: '#4caf50',
     red: '#f44336',
@@ -116,7 +116,7 @@ export default function EntryCard({
     : (dark ? styles.entryCard(dark, false).background : styles.entryCard(false, false).background);
 
   const currentTagColor = entry.tagColor || TAG_COLORS.GREEN;
-  const borderColor = lightenColor(currentTagColor, 0.5);
+  const borderColor = lightenColor(currentTagColor, 0.3);
   const currentPortion =
     editingIdx === idx && editForm
       ? editForm.portion || { size: null, grams: null }

--- a/src/styles.js
+++ b/src/styles.js
@@ -78,12 +78,13 @@ const styles = {
     flexShrink: 0,
     boxSizing: 'border-box'
   }),
-  entryCard: (dark, isSymptomOnly = false) => ({
+  entryCard: (dark, isSymptomOnly = false, borderColor = 'transparent') => ({
     position: 'relative',
     marginBottom: 16,
     marginLeft: 5,
     padding: 12,
     borderRadius: 8,
+    border: `2px solid ${borderColor}`,
     background: isSymptomOnly
       ? (dark ? "#3c3c46" : "#f0f0f5")
       : (dark ? "#2a2a32" : "#fff"),


### PR DESCRIPTION
## Summary
- lighten emoji tag color to pastel
- draw a border around each entry card using this color

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684ffb0ddf1c8332a28acdcb75376e33