### PR TITLE
Enable multiline food input

### DIFF
--- a/src/components/EntryCard.js
+++ b/src/components/EntryCard.js
@@ -156,7 +156,7 @@ export default function EntryCard({
         el.style.height = `${el.scrollHeight}px`;
       }
     }
-  }, [editForm.food, editingIdx]);
+  }, [editingIdx, editForm ? editForm.food : null]);
   const isSymptomOnlyEntry = !entry.food && (entry.symptoms || []).length > 0;
   const sortedAllDisplay = sortSymptomsByTime(
     (entry.symptoms || []).map(s => ({

--- a/src/components/EntryCard.js
+++ b/src/components/EntryCard.js
@@ -128,6 +128,7 @@ export default function EntryCard({
   const [showDateInput, setShowDateInput] = useState(false);
   const dateInputRef = useRef(null);
   const foodTextareaRef = useRef(null);
+  const symptomTextareaRef = useRef(null);
   const lastFoodTapRef = useRef(0);
   const lastSymptomInputTapRef = useRef(0);
   const lastSymptomTapRefs = useRef({});
@@ -157,6 +158,16 @@ export default function EntryCard({
       }
     }
   }, [editingIdx, editForm ? editForm.food : null]);
+
+  useEffect(() => {
+    if (editingIdx === idx) {
+      const el = symptomTextareaRef.current;
+      if (el) {
+        el.style.height = 'auto';
+        el.style.height = `${el.scrollHeight}px`;
+      }
+    }
+  }, [editingIdx, editForm ? editForm.symptomInput : null]);
   const isSymptomOnlyEntry = !entry.food && (entry.symptoms || []).length > 0;
   const sortedAllDisplay = sortSymptomsByTime(
     (entry.symptoms || []).map(s => ({
@@ -494,14 +505,19 @@ export default function EntryCard({
 
           <div style={{ marginBottom: 40 }}>
             <div id="edit-symptom-input-container" style={{ position: 'relative', marginBottom: '8px' }}>
-              <input
-                className="hide-datalist-arrow"
+              <textarea
+                ref={symptomTextareaRef}
+                rows={1}
                 placeholder={t('Symptom hinzufügen...')}
                 value={editForm.symptomInput}
-                onChange={e => setEditForm(fm => ({ ...fm, symptomInput: e.target.value }))}
+                onChange={e => {
+                  setEditForm(fm => ({ ...fm, symptomInput: e.target.value }));
+                  e.target.style.height = 'auto';
+                  e.target.style.height = `${e.target.scrollHeight}px`;
+                }}
                 onClick={handleNewSymptomTap}
                 onFocus={handleFocus}
-                style={{ ...styles.smallInput, width: '100%', paddingRight: '30px' }}
+                style={{ ...styles.textarea, fontSize: 16, width: '100%', paddingRight: '30px', marginTop: 0 }}
               />
               <button
                 className="quick-arrow"

--- a/src/components/EntryCard.js
+++ b/src/components/EntryCard.js
@@ -127,6 +127,7 @@ export default function EntryCard({
   );
   const [showDateInput, setShowDateInput] = useState(false);
   const dateInputRef = useRef(null);
+  const foodTextareaRef = useRef(null);
   const lastFoodTapRef = useRef(0);
   const lastSymptomInputTapRef = useRef(0);
   const lastSymptomTapRefs = useRef({});
@@ -146,6 +147,16 @@ export default function EntryCard({
       input?.showPicker?.();
     }
   }, [showDateInput]);
+
+  useEffect(() => {
+    if (editingIdx === idx) {
+      const el = foodTextareaRef.current;
+      if (el) {
+        el.style.height = 'auto';
+        el.style.height = `${el.scrollHeight}px`;
+      }
+    }
+  }, [editForm.food, editingIdx]);
   const isSymptomOnlyEntry = !entry.food && (entry.symptoms || []).length > 0;
   const sortedAllDisplay = sortSymptomsByTime(
     (entry.symptoms || []).map(s => ({
@@ -428,13 +439,19 @@ export default function EntryCard({
           )}
           <div style={{ display: 'flex', alignItems: 'center', gap: '4px', marginBottom: '40px', marginTop: '4px' }}>
             <div id="edit-food-input-container" style={{ position: 'relative', flexGrow: 1 }}>
-              <input
+              <textarea
+                ref={foodTextareaRef}
+                rows={1}
                 placeholder={t('Eintrag...')}
                 value={editForm.food}
-                onChange={e => setEditForm(fm => ({ ...fm, food: e.target.value }))}
+                onChange={e => {
+                  setEditForm(fm => ({ ...fm, food: e.target.value }));
+                  e.target.style.height = 'auto';
+                  e.target.style.height = `${e.target.scrollHeight}px`;
+                }}
                 onClick={handleFoodTap}
                 onFocus={handleFocus}
-                style={{ ...styles.input, flexGrow: 1, width: '100%', paddingRight: '30px' }}
+                style={{ ...styles.textarea, fontSize: 16, width: '100%', paddingRight: '30px', marginTop: 0 }}
               />
               <button
                 className="quick-arrow"

--- a/src/components/NewEntryForm.js
+++ b/src/components/NewEntryForm.js
@@ -48,6 +48,7 @@ export default function NewEntryForm({
 }) {
   const categoryRowRef = useRef(null);
   const formRef = useRef(null);
+  const foodTextareaRef = useRef(null);
   const foodQuickBtnRef = useRef(null);
   const foodQuickMenuRef = useRef(null);
   const symptomQuickBtnRef = useRef(null);
@@ -125,15 +126,29 @@ export default function NewEntryForm({
     filterMenuOpen,
     setFilterMenuOpen,
   ]);
+
+  useEffect(() => {
+    const el = foodTextareaRef.current;
+    if (el) {
+      el.style.height = 'auto';
+      el.style.height = `${el.scrollHeight}px`;
+    }
+  }, [newForm.food]);
   return (
     <div ref={formRef} className="new-entry-form" style={{ marginBottom: 24 }}>
       <div id="food-input-container" style={{ position: 'relative', marginBottom: 8, display: 'flex', alignItems: 'center', gap: '6px' }}>
-        <input
+        <textarea
+          ref={foodTextareaRef}
+          rows={1}
           placeholder={TAG_COLOR_NAMES[newForm.tagColor] ? `${t(TAG_COLOR_NAMES[newForm.tagColor])}...` : t('Eintrag...')}
           value={newForm.food}
-          onChange={e => setNewForm(fm => ({ ...fm, food: e.target.value }))}
+          onChange={e => {
+            setNewForm(fm => ({ ...fm, food: e.target.value }));
+            e.target.style.height = 'auto';
+            e.target.style.height = `${e.target.scrollHeight}px`;
+          }}
           onFocus={handleFocus}
-          style={{ ...styles.input, flexGrow: 1, paddingRight: '32px' }}
+          style={{ ...styles.textarea, fontSize: 16, paddingRight: '32px', marginTop: 0 }}
         />
         <button
           ref={foodQuickBtnRef}

--- a/src/components/NewEntryForm.js
+++ b/src/components/NewEntryForm.js
@@ -49,6 +49,7 @@ export default function NewEntryForm({
   const categoryRowRef = useRef(null);
   const formRef = useRef(null);
   const foodTextareaRef = useRef(null);
+  const symptomTextareaRef = useRef(null);
   const foodQuickBtnRef = useRef(null);
   const foodQuickMenuRef = useRef(null);
   const symptomQuickBtnRef = useRef(null);
@@ -134,6 +135,14 @@ export default function NewEntryForm({
       el.style.height = `${el.scrollHeight}px`;
     }
   }, [newForm.food]);
+
+  useEffect(() => {
+    const el = symptomTextareaRef.current;
+    if (el) {
+      el.style.height = 'auto';
+      el.style.height = `${el.scrollHeight}px`;
+    }
+  }, [newForm.symptomInput]);
   return (
     <div ref={formRef} className="new-entry-form" style={{ marginBottom: 24 }}>
       <div id="food-input-container" style={{ position: 'relative', marginBottom: 8, display: 'flex', alignItems: 'center', gap: '6px' }}>
@@ -287,12 +296,18 @@ export default function NewEntryForm({
 
       <div style={{ marginBottom: 8 }}>
       <div id="symptom-input-container" style={{ position: 'relative', marginBottom: '8px' }}>
-        <input
+        <textarea
+          ref={symptomTextareaRef}
+          rows={1}
           placeholder={t('Symptom...')}
           value={newForm.symptomInput}
-          onChange={e => setNewForm(fm => ({ ...fm, symptomInput: e.target.value }))}
+          onChange={e => {
+            setNewForm(fm => ({ ...fm, symptomInput: e.target.value }));
+            e.target.style.height = 'auto';
+            e.target.style.height = `${e.target.scrollHeight}px`;
+          }}
           onFocus={handleFocus}
-          style={{ ...styles.smallInput, width: '100%', paddingRight: '30px' }}
+          style={{ ...styles.textarea, fontSize: 16, width: '100%', paddingRight: '30px', marginTop: 0 }}
         />
         <button
           ref={symptomQuickBtnRef}

--- a/src/components/SymTag.js
+++ b/src/components/SymTag.js
@@ -9,8 +9,25 @@ const SymTag = ({ txt, time, strength, dark, onDel, onClick }) => {
   const tagTextColor = "#1a1f3d";
   const displayStrength = Math.min(parseInt(strength) || 1, 3);
 
+  const containerRef = React.useRef(null);
+  const timeRef = React.useRef(null);
+  const [wrapped, setWrapped] = React.useState(false);
+
+  React.useLayoutEffect(() => {
+    const update = () => {
+      const c = containerRef.current;
+      const tEl = timeRef.current;
+      if (c && tEl) {
+        setWrapped(tEl.offsetTop > c.offsetTop);
+      }
+    };
+    update();
+    window.addEventListener('resize', update);
+    return () => window.removeEventListener('resize', update);
+  }, [txt, time, strength]);
+
   return (
-    <div onClick={onClick} style={{
+    <div ref={containerRef} onClick={onClick} style={{
       display: "inline-flex",
       alignItems: "center",
       background: tagBackgroundColor,
@@ -36,13 +53,18 @@ const SymTag = ({ txt, time, strength, dark, onDel, onClick }) => {
       }}>
         {txt}
       </span>
-      <span style={{
-        display: 'inline-flex',
-        alignItems: 'center',
-        whiteSpace: 'nowrap',
-        marginLeft: 8,
-        flexShrink: 0
-      }}>
+      <span
+        ref={timeRef}
+        style={{
+          display: 'inline-flex',
+          alignItems: 'center',
+          whiteSpace: 'nowrap',
+          marginLeft: wrapped ? 0 : 8,
+          flexShrink: 0,
+          flexBasis: wrapped ? '100%' : 'auto',
+          marginTop: wrapped ? 2 : 0
+        }}
+      >
         <span style={{ fontSize: 12, opacity: 0.8 }}>
           {t(TIME_CHOICES.find(opt => opt.value === time)?.label || `${time} min`)}
         </span>

--- a/src/components/SymTag.js
+++ b/src/components/SymTag.js
@@ -12,7 +12,7 @@ const SymTag = ({ txt, time, strength, dark, onDel, onClick }) => {
   return (
     <div onClick={onClick} style={{
       display: "inline-flex",
-      alignItems: "flex-start",
+      alignItems: "center",
       background: tagBackgroundColor,
       color: tagTextColor,
       borderRadius: 6,
@@ -27,6 +27,8 @@ const SymTag = ({ txt, time, strength, dark, onDel, onClick }) => {
       flexWrap: "wrap"
     }}>
       <span style={{
+        flex: '1 1 auto',
+        minWidth: 0,
         overflowWrap: 'break-word',
         wordBreak: 'break-word',
         whiteSpace: 'normal',
@@ -38,7 +40,8 @@ const SymTag = ({ txt, time, strength, dark, onDel, onClick }) => {
         display: 'inline-flex',
         alignItems: 'center',
         whiteSpace: 'nowrap',
-        marginLeft: 8
+        marginLeft: 8,
+        flexShrink: 0
       }}>
         <span style={{ fontSize: 12, opacity: 0.8 }}>
           {t(TIME_CHOICES.find(opt => opt.value === time)?.label || `${time} min`)}

--- a/src/components/SymTag.js
+++ b/src/components/SymTag.js
@@ -17,7 +17,8 @@ const SymTag = ({ txt, time, strength, dark, onDel, onClick }) => {
       borderRadius: 6, padding: "6px 10px",
       margin: "3px 4px 3px 0", fontSize: 14,
       cursor: onClick ? "pointer" : "default",
-      overflowWrap: "break-word", whiteSpace: "normal"
+      overflowWrap: "break-word", whiteSpace: "normal",
+      wordBreak: "break-word", maxWidth: "100%", flexWrap: "wrap"
     }}>
       {strength && (
         <span style={{

--- a/src/components/SymTag.js
+++ b/src/components/SymTag.js
@@ -8,7 +8,6 @@ const SymTag = ({ txt, time, strength, dark, onDel, onClick }) => {
   const tagBackgroundColor = "#fafafa";
   const tagTextColor = "#1a1f3d";
   const displayStrength = Math.min(parseInt(strength) || 1, 3);
-  const indentLeft = strength ? 21 : 0; // align "time" text with symptom text
 
   return (
     <div onClick={onClick} style={{
@@ -27,27 +26,6 @@ const SymTag = ({ txt, time, strength, dark, onDel, onClick }) => {
       maxWidth: "100%",
       flexWrap: "wrap"
     }}>
-      {strength && (
-        <span style={{
-            display: 'inline-flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-            width: '16px',
-            height: '16px',
-            borderRadius: '50%',
-            backgroundColor: 'rgba(255, 255, 255, 0.2)',
-            color: '#333333',
-            fontSize: '10px',
-            fontWeight: 'bold',
-            marginRight: '5px',
-            lineHeight: 1,
-            flexShrink: 0,
-            border: `2px solid ${getStrengthColor(displayStrength)}`,
-            boxSizing: 'border-box',
-        }}>
-            {displayStrength}
-        </span>
-      )}
       <span style={{
         overflowWrap: 'break-word',
         wordBreak: 'break-word',
@@ -56,14 +34,36 @@ const SymTag = ({ txt, time, strength, dark, onDel, onClick }) => {
       }}>
         {txt}
       </span>
+      {' '}
       <span style={{
-        flexBasis: '100%',
-        paddingLeft: `${indentLeft}px`,
-        marginTop: 2,
-        fontSize: 12,
-        opacity: 0.8
+        display: 'inline-flex',
+        alignItems: 'center',
+        whiteSpace: 'nowrap'
       }}>
-        {t(TIME_CHOICES.find(opt => opt.value === time)?.label || `${time} min`)}
+        <span style={{ fontSize: 12, opacity: 0.8 }}>
+          {t(TIME_CHOICES.find(opt => opt.value === time)?.label || `${time} min`)}
+        </span>
+        {strength && (
+          <span style={{
+              display: 'inline-flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              width: '16px',
+              height: '16px',
+              borderRadius: '50%',
+              backgroundColor: 'rgba(255, 255, 255, 0.2)',
+              color: '#333333',
+              fontSize: '10px',
+              fontWeight: 'bold',
+              marginLeft: '5px',
+              lineHeight: 1,
+              flexShrink: 0,
+              border: `2px solid ${getStrengthColor(displayStrength)}`,
+              boxSizing: 'border-box',
+          }}>
+              {displayStrength}
+          </span>
+        )}
       </span>
       {onDel && (
         <span onClick={e => { e.stopPropagation(); onDel(); }} style={{

--- a/src/components/SymTag.js
+++ b/src/components/SymTag.js
@@ -34,11 +34,11 @@ const SymTag = ({ txt, time, strength, dark, onDel, onClick }) => {
       }}>
         {txt}
       </span>
-      {' '}
       <span style={{
         display: 'inline-flex',
         alignItems: 'center',
-        whiteSpace: 'nowrap'
+        whiteSpace: 'nowrap',
+        marginLeft: 8
       }}>
         <span style={{ fontSize: 12, opacity: 0.8 }}>
           {t(TIME_CHOICES.find(opt => opt.value === time)?.label || `${time} min`)}

--- a/src/components/SymTag.js
+++ b/src/components/SymTag.js
@@ -27,7 +27,7 @@ const SymTag = ({ txt, time, strength, dark, onDel, onClick }) => {
       flexWrap: "wrap"
     }}>
       <span style={{
-        flex: '1 1 auto',
+        flex: '0 1 auto',
         minWidth: 0,
         overflowWrap: 'break-word',
         wordBreak: 'break-word',

--- a/src/components/SymTag.js
+++ b/src/components/SymTag.js
@@ -8,17 +8,24 @@ const SymTag = ({ txt, time, strength, dark, onDel, onClick }) => {
   const tagBackgroundColor = "#fafafa";
   const tagTextColor = "#1a1f3d";
   const displayStrength = Math.min(parseInt(strength) || 1, 3);
+  const indentLeft = strength ? 21 : 0; // align "time" text with symptom text
 
   return (
     <div onClick={onClick} style={{
-      display: "inline-flex", alignItems: "center",
+      display: "inline-flex",
+      alignItems: "flex-start",
       background: tagBackgroundColor,
       color: tagTextColor,
-      borderRadius: 6, padding: "6px 10px",
-      margin: "3px 4px 3px 0", fontSize: 14,
+      borderRadius: 6,
+      padding: "6px 10px",
+      margin: "3px 4px 3px 0",
+      fontSize: 14,
       cursor: onClick ? "pointer" : "default",
-      overflowWrap: "break-word", whiteSpace: "normal",
-      wordBreak: "break-word", maxWidth: "100%", flexWrap: "wrap"
+      overflowWrap: "break-word",
+      whiteSpace: "normal",
+      wordBreak: "break-word",
+      maxWidth: "100%",
+      flexWrap: "wrap"
     }}>
       {strength && (
         <span style={{
@@ -41,13 +48,27 @@ const SymTag = ({ txt, time, strength, dark, onDel, onClick }) => {
             {displayStrength}
         </span>
       )}
-      {txt}
-      <span style={{ marginLeft: 8, fontSize: 12, opacity: 0.8, flexShrink: 0 }}>
+      <span style={{
+        overflowWrap: 'break-word',
+        wordBreak: 'break-word',
+        whiteSpace: 'normal',
+        maxWidth: '100%'
+      }}>
+        {txt}
+      </span>
+      <span style={{
+        flexBasis: '100%',
+        paddingLeft: `${indentLeft}px`,
+        marginTop: 2,
+        fontSize: 12,
+        opacity: 0.8
+      }}>
         {t(TIME_CHOICES.find(opt => opt.value === time)?.label || `${time} min`)}
       </span>
       {onDel && (
         <span onClick={e => { e.stopPropagation(); onDel(); }} style={{
-          marginLeft: 8, cursor: "pointer",
+          marginLeft: 8,
+          cursor: "pointer",
           fontSize: 16,
           color: "#c00",
           fontWeight: 700


### PR DESCRIPTION
## Summary
- make food input a dynamically sized `<textarea>` on both new entry form and edit form
- adjust height automatically based on content

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6850260080f883328f5df3146be00362