### PR TITLE
Adjust symptom tag spacing

### DIFF
--- a/src/components/SymTag.js
+++ b/src/components/SymTag.js
@@ -55,15 +55,15 @@ const SymTag = ({ txt, time, strength, dark, onDel, onClick }) => {
       </span>
       <span
         ref={timeRef}
-        style={{
-          display: 'inline-flex',
-          alignItems: 'center',
-          whiteSpace: 'nowrap',
-          marginLeft: wrapped ? 0 : 8,
-          flexShrink: 0,
-          flexBasis: wrapped ? '100%' : 'auto',
-          marginTop: wrapped ? 2 : 0
-        }}
+          style={{
+            display: 'inline-flex',
+            alignItems: 'center',
+            whiteSpace: 'nowrap',
+            marginLeft: wrapped ? 0 : 5,
+            flexShrink: 0,
+            flexBasis: wrapped ? '100%' : 'auto',
+            marginTop: wrapped ? 2 : 0
+          }}
       >
         <span style={{ fontSize: 12, opacity: 0.8 }}>
           {t(TIME_CHOICES.find(opt => opt.value === time)?.label || `${time} min`)}


### PR DESCRIPTION
## Summary
- shrink spacing between symptom text and its time/strength info

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6850fa1668d4833286f171758f3bfa80