### PR TITLE
Implement blur privacy menu

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -120,6 +120,30 @@ export default function App() {
     }
   });
 
+  const [blurCategories, setBlurCategories] = useState(() => {
+    try {
+      const saved = JSON.parse(localStorage.getItem('fd-blur-cats'));
+      if (Array.isArray(saved)) return saved;
+    } catch {}
+    return [TAG_COLORS.BROWN];
+  });
+
+  const toggleBlurCategory = cat => {
+    setBlurCategories(prev => {
+      const updated = prev.includes(cat)
+        ? prev.filter(c => c !== cat)
+        : [...prev, cat];
+      localStorage.setItem('fd-blur-cats', JSON.stringify(updated));
+      return updated;
+    });
+  };
+
+  useEffect(() => {
+    try {
+      localStorage.setItem('fd-blur-cats', JSON.stringify(blurCategories));
+    } catch {}
+  }, [blurCategories]);
+
   const dayOf = (entry) => entry.date.split(' ')[0];
 
   const entriesForDay = (currentEntries, day) =>
@@ -1007,6 +1031,7 @@ export default function App() {
               setShowEditSymptomQuick,
               showEditPortionQuickIdx,
               setShowEditPortionQuickIdx,
+              blurCategories,
             }}
             styles={styles}
             TAG_COLORS={TAG_COLORS}
@@ -1097,6 +1122,19 @@ export default function App() {
                 onChange={e => handlePersonChange('weight', e.target.value)}
                 style={styles.input}
               />
+              <div style={{ marginTop: 8, fontWeight: 600 }}>{t('Blur')}</div>
+              <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8 }}>
+                {[TAG_COLORS.GREEN, TAG_COLORS.PURPLE, TAG_COLORS.RED, TAG_COLORS.BLUE, TAG_COLORS.BROWN, TAG_COLORS.YELLOW, TAG_COLORS.GRAY].map(colorValue => (
+                  <button
+                    key={colorValue}
+                    onClick={() => toggleBlurCategory(colorValue)}
+                    style={styles.categoryButton(colorValue, blurCategories.includes(colorValue), dark)}
+                    title={t(TAG_COLOR_NAMES[colorValue] || colorValue)}
+                  >
+                    {TAG_COLOR_ICONS[colorValue]}
+                  </button>
+                ))}
+              </div>
               <button
                 onClick={closePerson}
                 style={{ ...styles.buttonSecondary('#1976d2'), marginTop: 8 }}

--- a/src/components/EntryCard.js
+++ b/src/components/EntryCard.js
@@ -118,6 +118,7 @@ export default function EntryCard({
   setShowEditSymptomQuick,
   showEditPortionQuickIdx,
   setShowEditPortionQuickIdx,
+  blurCategories = [],
   marginBottom = 16,
   linkPosition = null
 }) {
@@ -207,6 +208,11 @@ export default function EntryCard({
   const showPortion =
     [TAG_COLORS.GREEN, TAG_COLORS.RED].includes(entry.tagColor || TAG_COLORS.GREEN) &&
     (editingIdx === idx || (entry.portion && entry.portion.size));
+
+  const isBlurred =
+    blurCategories.includes(currentTagColor) &&
+    !(isExportingPdf || isPrinting) &&
+    editingIdx !== idx;
 
   useLayoutEffect(() => {
     const update = () => {
@@ -404,6 +410,7 @@ export default function EntryCard({
           )}
         </div>
       )}
+      <div style={{ filter: isBlurred ? 'blur(6px)' : 'none', overflow: 'hidden', borderRadius: 6 }}>
       {editingIdx === idx && !isExportingPdf ? (
         <>
           <button
@@ -762,51 +769,50 @@ export default function EntryCard({
             >
               {entry.comment}
             </div>
-          )}
+      )}
 
-          <>
-          <div
-            id={`tag-marker-${idx}`}
-            style={styles.categoryIcon(
-              editingIdx === idx ? '31px' : `${iconTop - 1}px`
-            )}
-            onClick={e => {
-              if (isExportingPdf) return;
-              e.stopPropagation();
-              setColorPickerOpenForIdx(colorPickerOpenForIdx === idx ? null : idx);
-              setNoteOpenIdx(null);
-              }}
-              title={
-                !isExportingPdf
-                  ? `${t('Markierung')}: ${t(TAG_COLOR_NAMES[currentTagColor] || 'Unbekannt')}. ${t('Klicken zum Ändern.')}`
-                  : `${t('Markierung')}: ${t(TAG_COLOR_NAMES[currentTagColor] || 'Unbekannt')}`
-              }
-            >
-              {TAG_COLOR_ICONS[currentTagColor]}
-            </div>
-
-            {!isExportingPdf && colorPickerOpenForIdx === idx && (
-              <div
-                id={`color-picker-popup-${idx}`}
-                style={styles.colorPickerPopup(dark)}
-                onClick={e => e.stopPropagation()}
-              >
-                {[TAG_COLORS.GREEN, TAG_COLORS.PURPLE, TAG_COLORS.RED, TAG_COLORS.BLUE, TAG_COLORS.BROWN, TAG_COLORS.YELLOW, TAG_COLORS.GRAY].map(colorValue => (
-                  <div
-                    key={colorValue}
-                    style={styles.colorPickerItem(colorValue, currentTagColor === colorValue, dark)}
-                    title={t(TAG_COLOR_NAMES[colorValue] || colorValue)}
-                    onClick={() => handleTagColorChange(idx, colorValue)}
-                  >
-                    {TAG_COLOR_ICONS[colorValue]}
-                  </div>
-                ))}
-              </div>
-            )}
-
-          </>
         </>
       )}
+      </div>
+      <div
+        id={`tag-marker-${idx}`}
+        style={styles.categoryIcon(
+          editingIdx === idx ? '31px' : `${iconTop - 1}px`
+        )}
+        onClick={e => {
+          if (isExportingPdf) return;
+          e.stopPropagation();
+          setColorPickerOpenForIdx(colorPickerOpenForIdx === idx ? null : idx);
+          setNoteOpenIdx(null);
+        }}
+        title={
+          !isExportingPdf
+            ? `${t('Markierung')}: ${t(TAG_COLOR_NAMES[currentTagColor] || 'Unbekannt')}. ${t('Klicken zum Ändern.')}`
+            : `${t('Markierung')}: ${t(TAG_COLOR_NAMES[currentTagColor] || 'Unbekannt')}`
+        }
+      >
+        {TAG_COLOR_ICONS[currentTagColor]}
+      </div>
+
+      {!isExportingPdf && colorPickerOpenForIdx === idx && (
+        <div
+          id={`color-picker-popup-${idx}`}
+          style={styles.colorPickerPopup(dark)}
+          onClick={e => e.stopPropagation()}
+        >
+          {[TAG_COLORS.GREEN, TAG_COLORS.PURPLE, TAG_COLORS.RED, TAG_COLORS.BLUE, TAG_COLORS.BROWN, TAG_COLORS.YELLOW, TAG_COLORS.GRAY].map(colorValue => (
+            <div
+              key={colorValue}
+              style={styles.colorPickerItem(colorValue, currentTagColor === colorValue, dark)}
+              title={t(TAG_COLOR_NAMES[colorValue] || colorValue)}
+              onClick={() => handleTagColorChange(idx, colorValue)}
+            >
+              {TAG_COLOR_ICONS[colorValue]}
+            </div>
+          ))}
+        </div>
+      )}
+
     </div>
   );
 }

--- a/src/translations.js
+++ b/src/translations.js
@@ -94,7 +94,8 @@ const translations = {
     'Benutzerdefiniert': 'Custom',
     'Gramm': 'grams',
     'Portion geändert': 'Portion updated',
-    'Portion entfernen': 'Remove portion'
+    'Portion entfernen': 'Remove portion',
+    'Blur': 'Blur'
   },
   de: {
     'Export': 'Exportieren',
@@ -110,7 +111,8 @@ const translations = {
     'Portion geändert': 'Portion geändert',
     'Portion entfernen': 'Portion entfernen',
     'Zu Favoriten hinzugefügt': 'Zu Favoriten hinzugefügt',
-    'Aus Favoriten entfernt': 'Aus Favoriten entfernt'
+    'Aus Favoriten entfernt': 'Aus Favoriten entfernt',
+    'Blur': 'Unschärfe'
   }
 };
 


### PR DESCRIPTION
## Summary
- add blur state with localStorage persistence
- show blur category selector under personal data
- remove blur on export
- translate Blur term
- keep borders and icons sharp when blurred

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68512fa5469883328ce138c5cc8a860e