### PR TITLE
Fix quick menu arrows in text fields

### DIFF
--- a/src/components/EntryCard.js
+++ b/src/components/EntryCard.js
@@ -475,13 +475,11 @@ export default function EntryCard({
                 className="quick-arrow"
                 onClick={() => setShowEditFoodQuick(s => !s)}
                 style={{
-                  ...styles.glassyIconButton(dark),
-                  padding: '4px',
+                  ...styles.textFieldIconButton,
                   position: 'absolute',
                   top: 'calc(50% - 2px)',
                   right: '6px',
-                  transform: 'translateY(-50%)',
-                  color: '#333'
+                  transform: 'translateY(-50%)'
                 }}
                 title={t('Favoriten')}
               >
@@ -530,13 +528,11 @@ export default function EntryCard({
                 className="quick-arrow"
                 onClick={() => setShowEditSymptomQuick(s => !s)}
                 style={{
-                  ...styles.glassyIconButton(dark),
-                  padding: '4px',
+                  ...styles.textFieldIconButton,
                   position: 'absolute',
                   top: '50%',
                   right: '6px',
-                  transform: 'translateY(-50%)',
-                  color: '#333'
+                  transform: 'translateY(-50%)'
                 }}
                 title={t('Favoriten')}
               >

--- a/src/components/NewEntryForm.js
+++ b/src/components/NewEntryForm.js
@@ -249,13 +249,11 @@ export default function NewEntryForm({
           className="quick-arrow"
           onClick={() => setShowFoodQuick(s => !s)}
           style={{
-            ...styles.glassyIconButton(dark),
-            padding: '4px',
+            ...styles.textFieldIconButton,
             position: 'absolute',
             top: 'calc(50% - 2px)',
             right: '48px',
-            transform: 'translateY(-50%)',
-            color: '#333'
+            transform: 'translateY(-50%)'
           }}
           title={t('Favoriten')}
         >
@@ -363,13 +361,11 @@ export default function NewEntryForm({
           className="quick-arrow"
           onClick={() => setShowSymptomQuick(s => !s)}
           style={{
-            ...styles.glassyIconButton(dark),
-            padding: '4px',
+            ...styles.textFieldIconButton,
             position: 'absolute',
             top: '50%',
             right: '6px',
-            transform: 'translateY(-50%)',
-            color: '#333'
+            transform: 'translateY(-50%)'
           }}
           title={t('Favoriten')}
         >

--- a/src/index.css
+++ b/src/index.css
@@ -8,7 +8,7 @@ body {
 }
 
 .quick-arrow {
-  color: #333;
+  color: #555;
 }
 
 input.hide-datalist-arrow {

--- a/src/styles.js
+++ b/src/styles.js
@@ -185,6 +185,18 @@ const styles = {
     alignItems: 'center',
     justifyContent: 'center',
   },
+  textFieldIconButton: {
+    background: 'transparent',
+    border: 'none',
+    padding: 0,
+    cursor: 'pointer',
+    fontSize: 18,
+    lineHeight: 1,
+    color: '#555',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
   glassyButton: (dark) => ({
     background: dark ? 'rgba(255, 255, 255, 0.08)' : 'rgba(0, 0, 0, 0.04)',
     border: dark ? '1px solid rgba(255, 255, 255, 0.15)' : '1px solid rgba(0, 0, 0, 0.1)',


### PR DESCRIPTION
## Summary
- add `textFieldIconButton` style
- use new style for quickmenu arrows in entry and symptom fields
- tweak arrow color

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68514f6410b48332bb74316cab931ca6