### PR TITLE
Limit QuickMenu width to entry field

### DIFF
--- a/src/components/EntryCard.js
+++ b/src/components/EntryCard.js
@@ -492,7 +492,7 @@ export default function EntryCard({
                     setEditForm(fm => ({ ...fm, food: f }));
                     setShowEditFoodQuick(false);
                   }}
-                  style={{ top: '32px', right: '6px' }}
+                  anchorRef={foodTextareaRef}
                 />
               )}
             </div>
@@ -545,7 +545,7 @@ export default function EntryCard({
                     setEditForm(fm => ({ ...fm, symptomInput: sym }));
                     setShowEditSymptomQuick(false);
                   }}
-                  style={{ top: '32px', right: '6px' }}
+                  anchorRef={symptomTextareaRef}
                 />
               )}
             </div>

--- a/src/components/NewEntryForm.js
+++ b/src/components/NewEntryForm.js
@@ -267,7 +267,7 @@ export default function NewEntryForm({
               setNewForm(fm => ({ ...fm, food: item }));
               setShowFoodQuick(false);
             }}
-            style={{ top: '40px', right: '48px' }}
+            anchorRef={foodTextareaRef}
           />
         )}
         <CameraButton onClick={() => fileRefNew.current?.click()} dark={dark} />
@@ -379,7 +379,7 @@ export default function NewEntryForm({
                 setNewForm(fm => ({ ...fm, symptomInput: sym }));
                 setShowSymptomQuick(false);
               }}
-              style={{ top: '32px', right: '6px' }}
+              anchorRef={symptomTextareaRef}
             />
           )}
         </div>

--- a/src/components/QuickMenu.js
+++ b/src/components/QuickMenu.js
@@ -1,20 +1,79 @@
-import React from 'react';
+import React, { useLayoutEffect, useRef, useState } from 'react';
 import useTranslation from '../useTranslation';
 
-const QuickMenu = React.forwardRef(function QuickMenu({ items, onSelect, style }, ref) {
+const QuickMenu = React.forwardRef(function QuickMenu({ items, onSelect, style, anchorRef }, ref) {
   const t = useTranslation();
+  const localRef = useRef(null);
+  const [adjust, setAdjust] = useState({});
+  const [limitStyle, setLimitStyle] = useState({});
+  const [posStyle, setPosStyle] = useState({});
+
+  const setRefs = el => {
+    localRef.current = el;
+    if (typeof ref === 'function') ref(el);
+    else if (ref) ref.current = el;
+  };
+
+  useLayoutEffect(() => {
+    const el = localRef.current;
+    if (!el) return;
+    if (anchorRef && anchorRef.current) {
+      const anchor = anchorRef.current;
+      const aw = anchor.offsetWidth;
+      if (aw) {
+        setLimitStyle({ width: aw });
+      }
+      const parent = anchor.offsetParent;
+      if (parent) {
+        const anchorRect = anchor.getBoundingClientRect();
+        const parentRect = parent.getBoundingClientRect();
+        setPosStyle({
+          left: anchorRect.left - parentRect.left,
+          top: anchorRect.bottom - parentRect.top,
+        });
+      } else {
+        setPosStyle({
+          left: anchor.offsetLeft,
+          top: anchor.offsetTop + anchor.offsetHeight,
+        });
+      }
+    }
+    const rect = el.getBoundingClientRect();
+    let dx = 0;
+    let dy = 0;
+    if (rect.right > window.innerWidth) dx -= rect.right - window.innerWidth + 4;
+    if (rect.left < 0) dx += -rect.left + 4;
+    if (rect.bottom > window.innerHeight) dy -= rect.bottom - window.innerHeight + 4;
+    if (rect.top < 0) dy += -rect.top + 4;
+    if (dx !== 0 || dy !== 0) {
+      setAdjust({ transform: `translate(${dx}px, ${dy}px)` });
+    }
+  }, [style, items, anchorRef]);
+
   return (
     <div
-      ref={ref}
+      ref={setRefs}
       className="quick-menu"
-      style={{ position: 'absolute', background: '#fff', border: '1px solid #ccc', borderRadius: 4, zIndex: 50, ...style }}
+      style={{
+        position: 'absolute',
+        background: '#fff',
+        border: '1px solid #ccc',
+        borderRadius: 4,
+        zIndex: 50,
+        overflowX: 'auto',
+        ...posStyle,
+        ...style,
+        ...limitStyle,
+        ...adjust,
+      }}
     >
       {items.length > 0 ? (
         items.map(item => (
           <div
             key={item}
             onClick={() => onSelect(item)}
-            style={{ padding: '4px 8px', cursor: 'pointer', whiteSpace: 'nowrap', color: '#222' }}
+            style={{ padding: '4px 8px', cursor: 'pointer', whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis', color: '#222' }}
+            title={t(item)}
           >
             {t(item)}
           </div>


### PR DESCRIPTION
## Summary
- restrict QuickMenu width using the triggering text area's size
- adjust QuickMenu position based on the textarea location
- remove fixed styles from NewEntryForm and EntryCard QuickMenu calls

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6851585cf3d8833285d9e700b628dd23