### PR TITLE
Add legend and selectable PDF export

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -4,7 +4,7 @@ import React, { useState, useRef, useEffect } from "react";
 import { exportTableToPdf } from "./utils/pdf";
 
 import styles from "./styles";
-import { SYMPTOM_CHOICES, TIME_CHOICES, TAG_COLORS, TAG_COLOR_NAMES, TAG_COLOR_ICONS } from "./constants";
+import { SYMPTOM_CHOICES, TIME_CHOICES, TAG_COLORS, TAG_COLOR_NAMES, TAG_COLOR_ICONS, PORTION_COLORS} from "./constants";
 import { resizeToJpeg, now, vibrate, getTodayDateString, parseDateString, toDateTimePickerFormat, fromDateTimePickerFormat, sortSymptomsByTime, determineTagColor } from "./utils";
 import ExportButton from "./components/ExportButton";
 import LanguageButton from "./components/LanguageButton";
@@ -15,7 +15,7 @@ import SymTag from "./components/SymTag";
 import NewEntryForm from "./components/NewEntryForm";
 import QuickMenu from "./components/QuickMenu";
 import FilterMenu from "./components/FilterMenu";
-import DayGroup from "./components/DayGroup";
+import Legend from './components/Legend';
 import { LanguageContext } from './LanguageContext';
 import useTranslation from './useTranslation';
 import useNewEntryForm from "./hooks/useNewEntryForm";
@@ -1039,6 +1039,7 @@ export default function App() {
             language={language}
           />
         ))}
+        {isExporting && <Legend TAG_COLOR_ICONS={TAG_COLOR_ICONS} TAG_COLOR_NAMES={TAG_COLOR_NAMES} PORTION_COLORS={PORTION_COLORS} dark={dark} />}
       </div>
       {linkChoice && (
         <div

--- a/src/components/Legend.js
+++ b/src/components/Legend.js
@@ -1,0 +1,52 @@
+import React from 'react';
+import useTranslation from '../useTranslation';
+
+const sizeMap = {
+  S: 'Small',
+  M: 'Medium',
+  L: 'Large'
+};
+
+const Legend = ({ TAG_COLOR_ICONS, TAG_COLOR_NAMES, PORTION_COLORS, dark }) => {
+  const t = useTranslation();
+  const textColor = dark ? '#f0f0f8' : '#333';
+  return (
+    <div style={{ marginTop: 16, fontSize: 14, color: textColor }}>
+      <div style={{ fontWeight: 600, marginBottom: 8 }}>{t('Legende')}</div>
+      <div style={{ marginBottom: 8 }}>
+        <div style={{ fontWeight: 600, marginBottom: 4 }}>{t('Kategorien')}</div>
+        <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8 }}>
+          {Object.entries(TAG_COLOR_ICONS).map(([color, icon]) => (
+            <div key={color} style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
+              <span>{icon}</span>
+              <span>{t(TAG_COLOR_NAMES[color] || color)}</span>
+            </div>
+          ))}
+        </div>
+      </div>
+      <div>
+        <div style={{ fontWeight: 600, marginBottom: 4 }}>{t('Portionsgrößen')}</div>
+        <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8 }}>
+          {Object.entries(PORTION_COLORS).map(([size, color]) => (
+            <div key={size} style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
+              <span style={{
+                display: 'inline-block',
+                width: 18,
+                height: 18,
+                lineHeight: '18px',
+                textAlign: 'center',
+                borderRadius: 4,
+                backgroundColor: color,
+                color: '#fff',
+                fontSize: 12
+              }}>{size}</span>
+              <span>{t(sizeMap[size])}</span>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default Legend;

--- a/src/translations.js
+++ b/src/translations.js
@@ -95,7 +95,12 @@ const translations = {
     'Gramm': 'grams',
     'Portion geändert': 'Portion updated',
     'Portion entfernen': 'Remove portion',
-    'Blur': 'Blur'
+    'Blur': 'Blur',
+    'Legende': 'Legend',
+    'Portionsgrößen': 'Portion sizes',
+    'Small': 'Small',
+    'Medium': 'Medium',
+    'Large': 'Large'
   },
   de: {
     'Export': 'Exportieren',
@@ -112,7 +117,12 @@ const translations = {
     'Portion entfernen': 'Portion entfernen',
     'Zu Favoriten hinzugefügt': 'Zu Favoriten hinzugefügt',
     'Aus Favoriten entfernt': 'Aus Favoriten entfernt',
-    'Blur': 'Unschärfe'
+    'Blur': 'Unschärfe',
+    'Legende': 'Legende',
+    'Portionsgrößen': 'Portionsgrößen',
+    'Small': 'Klein',
+    'Medium': 'Mittel',
+    'Large': 'Groß'
   }
 };
 

--- a/src/utils/pdf.js
+++ b/src/utils/pdf.js
@@ -1,4 +1,4 @@
-import html2pdf from 'html2pdf.js';
+import { jsPDF } from 'jspdf';
 
 export async function exportTableToPdf(el) {
   if (!el) return;
@@ -42,12 +42,9 @@ export async function exportTableToPdf(el) {
     const bodyBg = getComputedStyle(document.body).backgroundColor;
     el.style.backgroundColor = bodyBg;
 
-    await html2pdf().from(el).set({
-      margin: 10,
-      filename: 'FoodDiary.pdf',
-      html2canvas: { scale: 2, useCORS: true, backgroundColor: bodyBg },
-      jsPDF: { unit: 'pt', format: 'a4', orientation: 'portrait' }
-    }).save();
+    const doc = new jsPDF({ unit: 'pt', format: 'a4', orientation: 'portrait' });
+    await doc.html(el, { margin: 10, html2canvas: { scale: 2, useCORS: true, backgroundColor: bodyBg } });
+    doc.save('FoodDiary.pdf');
     el.style.backgroundColor = prevBackground;
     return true;
   } catch (error) {


### PR DESCRIPTION
## Summary
- add Legend component describing category icons and portion sizes
- show Legend when exporting
- update translations with legend strings
- export PDFs using jsPDF.html so text is selectable

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851be1eea54833299ac9d6a6e2e1deb